### PR TITLE
[METAED-1333] CI workflow improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,9 @@
 name: Lint and Test
 on:
-  workflow_dispatch:
   pull_request:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   lint:
@@ -78,6 +80,17 @@ jobs:
     runs-on: ubuntu-latest
     env:
       SA_PASSWORD: abcdefgh1!
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2019-latest
+        env:
+          SA_PASSWORD: ${{ env.SA_PASSWORD }}
+          ACCEPT_EULA: "Y"
+          MSSQL_PID: "Express"
+        ports:
+          - 1433:1433
+        options: "--name mssql"
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b # v3.2.0
@@ -99,12 +112,6 @@ jobs:
       - name: Install dependencies
         if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
         run: yarn install
-
-      - name: Start Docker for SQL Server
-        # Starting before unit tests to give plenty of spin-up time - unit tests do not depend on this. How to do it?
-        run: |
-          docker run -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=${{ env.SA_PASSWORD }}' -e 'MSSQL_PID=Express' -p 1433:1433 \
-            --name mssql -d mcr.microsoft.com/mssql/server:2019-latest
 
       - name: Create SQL Server Testing Database
         run: |


### PR DESCRIPTION
- Use cache for node_modules.
- Split CI workflow into 4 jobs:
    - Lint
    - Unit Test
    - SQL Server Tests
    - Postgres Tests.
- Use server container for SQL Server to improve performance and avoid having to wait for container to be ready.

In my fork, this improved the job run time from 24 to 19 minutes.

![image](https://user-images.githubusercontent.com/5459528/209413239-27844dfd-b0c6-45b8-9752-49de5821ec06.png)

![image](https://user-images.githubusercontent.com/5459528/209413260-040a2cba-0e54-415d-95ee-e9a3f5d82fa6.png)