### PR TITLE
[METAED-1334] Create Logger

### DIFF
--- a/packages/metaed-console/src/metaed-console.ts
+++ b/packages/metaed-console/src/metaed-console.ts
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import chalk from 'chalk';
 import path from 'path';
-import winston from 'winston';
 import Yargs from 'yargs';
 import {
   executePipeline,
@@ -10,9 +9,7 @@ import {
   MetaEdConfiguration,
   findDataStandardVersions,
 } from '@edfi/metaed-core';
-import { State, SemVer } from '@edfi/metaed-core';
-
-winston.configure({ transports: [new winston.transports.Console()], format: winston.format.cli() });
+import { State, SemVer, Logger } from '@edfi/metaed-core';
 
 export async function metaEdConsole() {
   const { argv } = Yargs.usage('Usage: $0 [options]')
@@ -51,10 +48,10 @@ export async function metaEdConsole() {
   const dataStandardVersions: SemVer[] = findDataStandardVersions(state.metaEdConfiguration.projects);
 
   if (dataStandardVersions.length === 0) {
-    winston.error('No data standard project found.  Aborting.');
+    Logger.error('No data standard project found.  Aborting.');
     process.exitCode = 1;
   } else if (dataStandardVersions.length > 1) {
-    winston.error('Multiple data standard projects found.  Aborting.');
+    Logger.error('Multiple data standard projects found.  Aborting.');
     process.exitCode = 1;
   } else {
     // eslint-disable-next-line prefer-destructuring
@@ -63,10 +60,10 @@ export async function metaEdConsole() {
       const { failure } = await executePipeline(state);
       process.exitCode = !state.validationFailure.some((vf) => vf.category === 'error') && !failure ? 0 : 1;
     } catch (e) {
-      winston.error(e);
+      Logger.error(e);
       process.exitCode = 1;
     }
   }
   const endTime = Date.now() - startTime;
-  winston.info(`Done in ${chalk.green(endTime > 1000 ? `${endTime / 1000}s` : `${endTime}ms`)}.`);
+  Logger.info(`Done in ${chalk.green(endTime > 1000 ? `${endTime / 1000}s` : `${endTime}ms`)}.`);
 }

--- a/packages/metaed-core/src/Logger.ts
+++ b/packages/metaed-core/src/Logger.ts
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+import winston from 'winston';
+
+const convertErrorToString = (err) => {
+  // Preserve any dictionary, but otherwise convert to string
+  if (err != null && err.constructor !== Object) {
+    return err.toString();
+  }
+  return err;
+};
+
+// Logger begins life "uninitialized" and in silent mode
+let isInitialized = false;
+
+// Create and set up a silent default logger transport - in case a library is using the default logger
+const transport = new winston.transports.Console();
+transport.silent = true;
+winston.configure({ transports: [transport] });
+
+// Set initial logger to silent
+let logger: winston.Logger = winston.createLogger({
+  transports: [transport],
+});
+
+/**
+ * This should be called by frontend services at startup, before logging. Because services can have
+ * multiple startup points (e.g. multiple lambdas), this checks if initialization has already happened.
+ */
+export function initializeLogging(): void {
+  if (isInitialized) return;
+
+  const offline = process.env.IS_LOCAL === 'true';
+  isInitialized = true;
+  logger = winston.createLogger({
+    level: process.env.LOG_LEVEL?.toLocaleLowerCase() ?? (offline ? 'debug' : 'info'),
+    transports: [
+      new winston.transports.Console({
+        format: winston.format.cli(),
+      }),
+    ],
+  });
+}
+
+export const Logger = {
+  fatal: (message: string, err?: any | null) => {
+    logger.error({ message, err: convertErrorToString(err) });
+    process.exit(1);
+  },
+  error: (message: string, err?: any | null) => {
+    logger.error({ message, error: convertErrorToString(err) });
+  },
+  warn: (message: string) => {
+    logger.warn({ message });
+  },
+  info: (message: string, extra?: any | null) => {
+    logger.info({ message, extra });
+  },
+  verbose: (message: string) => {
+    logger.verbose({ message });
+  },
+  debug: (message: string, extra?: any | null) => {
+    logger.debug({ message, extra });
+  },
+  trace: (message: string) => {
+    logger.debug({ message: JSON.stringify(message) });
+  },
+  child: () => Logger,
+};
+
+export function writeErrorToLog(moduleName: string, method: string, status?: number | undefined, error?: any): void {
+  Logger.error(`${moduleName}.${method} ${status || ''}`, error);
+}
+
+export function isDebugEnabled(): boolean {
+  return logger.levels[logger.level] >= logger.levels.debug;
+}
+
+export function isInfoEnabled(): boolean {
+  return logger.levels[logger.level] >= logger.levels.info;
+}

--- a/packages/metaed-core/src/file/FileSystemFilenameLoader.ts
+++ b/packages/metaed-core/src/file/FileSystemFilenameLoader.ts
@@ -1,17 +1,17 @@
 import ffs from 'final-fs';
 import path from 'path';
-import winston from 'winston';
 import { createMetaEdFile } from './MetaEdFile';
 import { FileSet } from './MetaEdFile';
 import { State } from '../State';
 import { MetaEdConfiguration } from '../MetaEdConfiguration';
+import { Logger } from '../Logger';
 
 export function loadFiles(state: State): boolean {
   let success = true;
   const { metaEdConfiguration }: { metaEdConfiguration: MetaEdConfiguration } = state;
 
   if (metaEdConfiguration.projects.length !== metaEdConfiguration.projectPaths.length) {
-    winston.error('FileSystemFilenameLoader: project metadata must be same length as project paths');
+    Logger.error('FileSystemFilenameLoader: project metadata must be same length as project paths');
     return false;
   }
 
@@ -60,22 +60,22 @@ export function loadFiles(state: State): boolean {
         fileSet.files.push(metaEdFile);
       });
 
-      winston.info(
+      Logger.info(
         `- ${inputDirectory.path} (${filenamesToLoad.length} .metaed file${filenamesToLoad.length > 1 ? 's' : ''} loaded)`,
       );
 
       fileSets.push(fileSet);
     } catch (exception) {
-      winston.error(`FileSystemFilenameLoader: Unable to read files at location '${inputDirectory.path}'.`, exception);
+      Logger.error(`FileSystemFilenameLoader: Unable to read files at location '${inputDirectory.path}'.`, exception);
       if (exception.code === 'ENOTEMPTY' || exception.code === 'EPERM') {
-        winston.error('Please close any files or folders that may be open in other applications.');
+        Logger.error('Please close any files or folders that may be open in other applications.');
       }
       success = false;
     }
   });
 
   if (!filenamesFoundInDirectories) {
-    winston.error('No MetaEd files found in any input directory.');
+    Logger.error('No MetaEd files found in any input directory.');
     success = false;
   }
 

--- a/packages/metaed-core/src/file/LoadFileIndex.ts
+++ b/packages/metaed-core/src/file/LoadFileIndex.ts
@@ -1,8 +1,8 @@
-import winston from 'winston';
 import { State } from '../State';
 import { createMetaEdFile } from './MetaEdFile';
 import { MetaEdFile, FileSet } from './MetaEdFile';
 import { createFileIndex } from './FileIndex';
+import { Logger } from '../Logger';
 
 function startNamespace(namespace: string, projectExtension: string, isExtension: boolean) {
   const adjustedProjectExtension = isExtension ? projectExtension : 'core';
@@ -15,7 +15,7 @@ function endNamespace() {
 
 export function loadFileIndex(state: State): void {
   if (state.loadedFileSet == null) {
-    winston.error('LoadFileIndex: no files to load found');
+    Logger.error('LoadFileIndex: no files to load found');
     return;
   }
 

--- a/packages/metaed-core/src/grammar/BuildParseTree.ts
+++ b/packages/metaed-core/src/grammar/BuildParseTree.ts
@@ -1,10 +1,10 @@
 import R from 'ramda';
-import winston from 'winston';
 import { ValidationFailure } from '../validator/ValidationFailure';
 import { MetaEdErrorListener } from './MetaEdErrorListener';
 import { State } from '../State';
 import { getAllContents, getFilenameAndLineNumber } from '../file/FileIndex';
 import { ParseTreeBuilder } from './ParseTreeBuilder';
+import { Logger } from '../Logger';
 
 export const buildParseTree = R.curry((parseTreeBuilder: ParseTreeBuilder, state: State): void => {
   const validationFailures: ValidationFailure[] = [];
@@ -13,7 +13,7 @@ export const buildParseTree = R.curry((parseTreeBuilder: ParseTreeBuilder, state
   const parseTree = parseTreeBuilder(errorListener, getAllContents(state.fileIndex));
 
   if (parseTree == null) {
-    winston.error('BuildParseTree: parse tree builder returned null for state metaEdFileIndex contents');
+    Logger.error('BuildParseTree: parse tree builder returned null for state metaEdFileIndex contents');
   }
 
   validationFailures.forEach((failure) => {

--- a/packages/metaed-core/src/grammar/ValidateSyntax.ts
+++ b/packages/metaed-core/src/grammar/ValidateSyntax.ts
@@ -1,15 +1,15 @@
 import R from 'ramda';
-import winston from 'winston';
 import { State } from '../State';
 import { ValidationFailure } from '../validator/ValidationFailure';
 import { MetaEdFile, FileSet } from '../file/MetaEdFile';
 import { createFileIndex, getFilenameAndLineNumber } from '../file/FileIndex';
 import { MetaEdErrorListener } from './MetaEdErrorListener';
 import { ParseTreeBuilder } from './ParseTreeBuilder';
+import { Logger } from '../Logger';
 
 export const validateSyntax = R.curry((parseTreeBuilder: ParseTreeBuilder, state: State): void => {
   if (state.loadedFileSet == null) {
-    winston.error('ValidateSyntax: no files to load found');
+    Logger.error('ValidateSyntax: no files to load found');
     return;
   }
 
@@ -20,7 +20,7 @@ export const validateSyntax = R.curry((parseTreeBuilder: ParseTreeBuilder, state
 
       const parseTree = parseTreeBuilder(errorListener, file.contents);
       if (parseTree == null) {
-        winston.error(`ValidateSyntax: parse tree builder returned null for file ${file.fullPath}`);
+        Logger.error(`ValidateSyntax: parse tree builder returned null for file ${file.fullPath}`);
       }
 
       validationFailures.forEach((failure: ValidationFailure) => {

--- a/packages/metaed-core/src/index.ts
+++ b/packages/metaed-core/src/index.ts
@@ -255,6 +255,7 @@ export { asTopLevelEntity, newTopLevelEntity } from './model/TopLevelEntity';
 export { normalizeDescriptorSuffix, normalizeEnumerationSuffix } from './Utility';
 export { isDataStandard, findDataStandardVersions } from './project/ProjectTypes';
 export { scanForProjects, overrideProjectNameAndNamespace } from './project/ProjectLoader';
+export { Logger } from './Logger';
 
 // for plugin testing
 export { MetaEdTextBuilder } from './grammar/MetaEdTextBuilder';

--- a/packages/metaed-core/src/pipeline/FileMapForValidationFailure.ts
+++ b/packages/metaed-core/src/pipeline/FileMapForValidationFailure.ts
@@ -1,6 +1,6 @@
 import chalk from 'chalk';
-import winston from 'winston';
 import { getFilenameAndLineNumber } from '../file/FileIndex';
+import { Logger } from '../Logger';
 import { State } from '../State';
 import { ValidationFailure } from '../validator/ValidationFailure';
 
@@ -13,11 +13,11 @@ function logValidationFailures(state: State): void {
     const logMessage = `  ${validationFailure.message}  ${chalk.gray(`${fullPath} (${adjustedLine}:${characterPosition})`)}`;
 
     if (validationFailure.category === 'error') {
-      winston.error(logMessage);
+      Logger.error(logMessage);
     } else if (validationFailure.category === 'warning') {
-      winston.warn(logMessage);
+      Logger.warn(logMessage);
     } else {
-      winston.info(logMessage);
+      Logger.info(logMessage);
     }
   });
 }

--- a/packages/metaed-core/src/pipeline/InitializeMetaEdEnvironment.ts
+++ b/packages/metaed-core/src/pipeline/InitializeMetaEdEnvironment.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import winston from 'winston';
+import { Logger } from '../Logger';
 import { State } from '../State';
 
 export function initializeMetaEdEnvironment(state: State): State {
@@ -10,6 +10,6 @@ export function initializeMetaEdEnvironment(state: State): State {
   const metaEdCorePackageJson = require(path.resolve(__dirname, '../../package.json')); // eslint-disable-line
   if (metaEdCorePackageJson.version != null) state.metaEd.metaEdVersion = metaEdCorePackageJson.version;
 
-  winston.info(`  Running MetaEd version ${state.metaEd.metaEdVersion}`);
+  Logger.info(`  Running MetaEd version ${state.metaEd.metaEdVersion}`);
   return state;
 }

--- a/packages/metaed-core/src/pipeline/Pipeline.ts
+++ b/packages/metaed-core/src/pipeline/Pipeline.ts
@@ -1,4 +1,3 @@
-import winston from 'winston';
 import { loadFiles } from '../file/FileSystemFilenameLoader';
 import { initializeMetaEdEnvironment } from './InitializeMetaEdEnvironment';
 import { validateSyntax } from '../grammar/ValidateSyntax';
@@ -18,48 +17,49 @@ import { loadPlugins } from '../plugin/LoadPlugins';
 import { initializeNamespaces } from './InitializeNamespaces';
 import { State } from '../State';
 import { PluginEnvironment } from '../plugin/PluginEnvironment';
+import { Logger } from '../Logger';
 
 export async function executePipeline(state: State): Promise<{ state: State; failure: boolean }> {
-  // winston.info('Validating configuration...');
+  // Logger.info('Validating configuration...');
   // validateConfiguration(state);
   // await nextMacroTask();
 
   let failure = false;
 
-  winston.debug('Initialize MetaEdEnvironment');
+  Logger.debug('Initialize MetaEdEnvironment');
   initializeMetaEdEnvironment(state);
   await nextMacroTask();
 
-  winston.info('Loading plugins');
+  Logger.info('Loading plugins');
   loadPlugins(state);
   await nextMacroTask();
 
-  winston.info('Loading .metaed files');
+  Logger.info('Loading .metaed files');
   if (!loadFiles(state)) return { state, failure: true };
   await nextMacroTask();
 
-  winston.debug('Validating syntax');
+  Logger.debug('Validating syntax');
   validateSyntax(buildTopLevelEntity, state);
   await nextMacroTask();
 
-  winston.debug('Loading file indexes');
+  Logger.debug('Loading file indexes');
   loadFileIndex(state);
   await nextMacroTask();
 
-  winston.debug('Building parse tree');
+  Logger.debug('Building parse tree');
   buildParseTree(buildMetaEd, state);
   await nextMacroTask();
 
-  winston.debug('Walking builders');
+  Logger.debug('Walking builders');
   await walkBuilders(state);
 
   initializeNamespaces(state);
   await nextMacroTask();
 
-  winston.debug('Loading plugin configuration files');
+  Logger.debug('Loading plugin configuration files');
   await loadPluginConfiguration(state);
 
-  winston.info('Running plugins');
+  Logger.info('Running plugins');
   // eslint-disable-next-line no-restricted-syntax
   for (const pluginManifest of state.pluginManifest) {
     const pluginEnvironment: PluginEnvironment | undefined = state.metaEd.plugin.get(pluginManifest.shortName);
@@ -69,10 +69,10 @@ export async function executePipeline(state: State): Promise<{ state: State; fai
       versionSatisfies(pluginEnvironment.targetTechnologyVersion, pluginManifest.technologyVersion)
     ) {
       try {
-        winston.info(`- ${pluginManifest.description}`);
+        Logger.info(`- ${pluginManifest.description}`);
         if (state.pipelineOptions.runValidators) {
           if (pluginManifest.metaEdPlugin.validator.length > 0) {
-            winston.debug(`- Running ${pluginManifest.metaEdPlugin.validator.length} validators...`);
+            Logger.debug(`- Running ${pluginManifest.metaEdPlugin.validator.length} validators...`);
           }
           runValidators(pluginManifest, state);
           await nextMacroTask();
@@ -87,7 +87,7 @@ export async function executePipeline(state: State): Promise<{ state: State; fai
 
         if (state.pipelineOptions.runEnhancers) {
           if (pluginManifest.metaEdPlugin.enhancer.length > 0) {
-            winston.debug(`- Running ${pluginManifest.metaEdPlugin.enhancer.length} enhancers...`);
+            Logger.debug(`- Running ${pluginManifest.metaEdPlugin.enhancer.length} enhancers...`);
           }
           await runEnhancers(pluginManifest, state);
           await nextMacroTask();
@@ -95,23 +95,23 @@ export async function executePipeline(state: State): Promise<{ state: State; fai
 
         if (state.pipelineOptions.runGenerators) {
           if (pluginManifest.metaEdPlugin.generator.length > 0) {
-            winston.debug(`- Running ${pluginManifest.metaEdPlugin.generator.length} generators...`);
+            Logger.debug(`- Running ${pluginManifest.metaEdPlugin.generator.length} generators...`);
           }
           await runGenerators(pluginManifest, state);
           await nextMacroTask();
         }
       } catch (err) {
         const message = `Plugin ${pluginManifest.shortName} threw exception '${err.message}'`;
-        winston.error(`  ${message}`);
+        Logger.error(`  ${message}`);
         state.pipelineFailure.push({ category: 'error', message });
-        winston.error(err.stack);
+        Logger.error(err.stack);
         failure = true;
       }
     }
   }
 
   if (state.pipelineOptions.runGenerators && !failure) {
-    winston.info('Writing output');
+    Logger.info('Writing output');
     if (!writeOutput(state)) return { state, failure: true };
     await nextMacroTask();
   }

--- a/packages/metaed-core/src/pipeline/WriteOutput.ts
+++ b/packages/metaed-core/src/pipeline/WriteOutput.ts
@@ -1,9 +1,9 @@
 import ffs from 'final-fs';
 import klawSync from 'klaw-sync';
 import path from 'path';
-import winston from 'winston';
 import { State } from '../State';
 import { GeneratorResult } from '../generator/GeneratorResult';
+import { Logger } from '../Logger';
 
 export const METAED_OUTPUT = 'MetaEdOutput';
 const LINUX_USER_FULL_CONTROL = 0o700;
@@ -18,7 +18,7 @@ function writeOutputFiles(result: GeneratorResult, outputDirectory: string) {
       ffs.writeFileSync(`${outputDirectory}/${folderName}/${output.fileName}`, output.resultString, 'utf-8');
     else if (output.resultStream)
       ffs.writeFileSync(`${outputDirectory}/${folderName}/${output.fileName}`, output.resultStream);
-    else winston.debug(`No output stream or string for ${result.generatorName}`);
+    else Logger.debug(`No output stream or string for ${result.generatorName}`);
   });
 }
 
@@ -34,12 +34,12 @@ export function execute(state: State): boolean {
     outputDirectory = path.resolve(defaultRootDirectory.path, METAED_OUTPUT);
   }
 
-  winston.info(`- Artifact Directory: ${outputDirectory}`);
+  Logger.info(`- Artifact Directory: ${outputDirectory}`);
 
   try {
     if (ffs.existsSync(outputDirectory)) {
       if (!outputDirectory.includes(METAED_OUTPUT)) {
-        winston.error(
+        Logger.error(
           `Unable to delete output directory at path "${outputDirectory}".  Output directory name must contain 'MetaEdOutput'.`,
         );
         return false;
@@ -49,7 +49,7 @@ export function execute(state: State): boolean {
         filter: (item) => ['.metaed', '.metaEd', '.MetaEd', '.METAED'].includes(path.extname(item.path)),
       });
       if (testForMetaEdFilePaths.length > 0) {
-        winston.error(`WriteOutput: MetaEd files found in output location '${outputDirectory}'. Not writing files.`);
+        Logger.error(`WriteOutput: MetaEd files found in output location '${outputDirectory}'. Not writing files.`);
         return false;
       }
       ffs.rmdirRecursiveSync(outputDirectory);
@@ -61,7 +61,7 @@ export function execute(state: State): boolean {
     state.generatorResults.forEach((result) => {
       // if (result is a Promise)
       if ((result as any).then) {
-        winston.debug('Resolving Promise:');
+        Logger.debug('Resolving Promise:');
         (result as any).then((resolvedResult) => {
           writeOutputFiles(resolvedResult, outputDirectory);
         });
@@ -71,9 +71,9 @@ export function execute(state: State): boolean {
     state.metaEdConfiguration.artifactDirectory = outputDirectory;
     return true;
   } catch (exception) {
-    winston.error(`WriteOutput: Unable to write files to output location '${outputDirectory}'.`, exception);
+    Logger.error(`WriteOutput: Unable to write files to output location '${outputDirectory}'.`, exception);
     if (exception.code === 'ENOTEMPTY' || exception.code === 'EPERM') {
-      winston.error('Please close any files or folders that may be open in other applications.');
+      Logger.error('Please close any files or folders that may be open in other applications.');
     }
     return false;
   }

--- a/packages/metaed-core/src/plugin/LoadPlugins.ts
+++ b/packages/metaed-core/src/plugin/LoadPlugins.ts
@@ -1,11 +1,10 @@
 import path from 'path';
-import winston from 'winston';
-// import semver from 'semver';
 import { scanDirectories, materializePlugin } from './PluginLoader';
 import { State } from '../State';
 import { PluginManifest } from './PluginManifest';
 import { NoMetaEdPlugin } from './MetaEdPlugin';
 import { newPluginEnvironment } from './PluginEnvironment';
+import { Logger } from '../Logger';
 
 const cachedPlugins: Map<string, PluginManifest[]> = new Map();
 
@@ -26,7 +25,7 @@ export function scanForPlugins(state: State): PluginManifest[] {
 
     if (pluginManifest.metaEdPlugin === NoMetaEdPlugin) {
       const message = `Could not load plugin ${pluginManifest.shortName}`;
-      winston.info(`  ${message}`);
+      Logger.info(`  ${message}`);
       state.pipelineFailure.push({ category: 'error', message });
       return;
     }
@@ -45,7 +44,7 @@ export function scanForPlugins(state: State): PluginManifest[] {
       // eslint-disable-line
       if (foundPlugins.find((plugin) => plugin.npmName === dependencyName) == null) {
         const message = `Plugin ${pluginManifest.shortName} requires a plugin named ${dependencyName} which was not found. Plugin not loaded.`;
-        winston.info(`  ${message}`);
+        Logger.info(`  ${message}`);
         state.pipelineFailure.push({ category: 'error', message });
         return;
       }
@@ -74,7 +73,7 @@ export function loadPlugins(state: State): void {
       ? state.metaEdConfiguration.pluginTechVersion[pluginManifest.shortName].targetTechnologyVersion
       : state.metaEdConfiguration.defaultPluginTechVersion;
 
-    winston.info(`- ${pluginManifest.shortName} version ${pluginManifest.version}, tech version ${targetTechnologyVersion}`);
+    Logger.info(`- ${pluginManifest.shortName} version ${pluginManifest.version}, tech version ${targetTechnologyVersion}`);
 
     state.metaEd.plugin.set(pluginManifest.shortName, {
       ...newPluginEnvironment(),

--- a/packages/metaed-core/src/plugin/PluginLoader.ts
+++ b/packages/metaed-core/src/plugin/PluginLoader.ts
@@ -2,12 +2,12 @@ import fs from 'final-fs';
 import path from 'path';
 import Topo from 'topo';
 import semver from 'semver';
-import winston from 'winston';
 import { NoMetaEdPlugin } from './MetaEdPlugin';
 import { PluginManifest } from './PluginManifest';
 import { MetaEdPlugin } from './MetaEdPlugin';
 import { SemVerRange } from '../MetaEdEnvironment';
 import { PipelineFailure } from '../pipeline/PipelineFailure';
+import { Logger } from '../Logger';
 
 // Resolve roughly like Typescript does with "node" strategy  (https://www.typescriptlang.org/docs/handbook/module-resolution.html)
 function mainModuleResolver(directory: string, packageJson: any): string {
@@ -92,7 +92,7 @@ export function scanDirectories(directories: string | string[]): {
           });
         } catch (err) {
           const message = `Attempted load of npm package ${manifest.npmName} plugin '${manifest.description}' failed due to dependency issue.`;
-          winston.error(`${message}`);
+          Logger.error(`${message}`);
           pipelineFailures.push({ category: 'error', message });
         }
       }
@@ -108,7 +108,7 @@ export function materializePlugin(pluginManifest: PluginManifest): PipelineFailu
   try {
     if (!pluginManifest.mainModule) {
       const message = `Attempted load of npm package ${pluginManifest.npmName} plugin '${pluginManifest.description}' at '${pluginManifest.mainModule}' failed.  Module entry point not found.`;
-      winston.error(`${message}`);
+      Logger.error(`${message}`);
       pipelineFailures.push({ category: 'error', message });
       return pipelineFailures;
     }
@@ -121,12 +121,12 @@ export function materializePlugin(pluginManifest: PluginManifest): PipelineFailu
       pluginManifest.metaEdPlugin = pluginFactory();
     } else {
       const message = `Attempted load of npm package ${pluginManifest.npmName} plugin '${pluginManifest.description}' at '${pluginManifest.mainModule}' failed. initialize() not found.`;
-      winston.error(`${message}`);
+      Logger.error(`${message}`);
       pipelineFailures.push({ category: 'error', message });
     }
   } catch (err) {
     const message = `Attempted load of npm package ${pluginManifest.npmName} plugin '${pluginManifest.description}' at '${pluginManifest.mainModule}' failed. Error message: ${err.message}`;
-    winston.error(`${message}`);
+    Logger.error(`${message}`);
     pipelineFailures.push({ category: 'error', message });
   }
 

--- a/packages/metaed-core/src/project/ProjectLoader.ts
+++ b/packages/metaed-core/src/project/ProjectLoader.ts
@@ -1,17 +1,17 @@
 import R from 'ramda';
 import fs from 'fs-extra';
 import path from 'path';
-import winston from 'winston';
 import chalk from 'chalk';
 import klawSync from 'klaw-sync';
 import { MetaEdProjectPathPairs } from './ProjectTypes';
 import { deriveNamespaceFromProjectName } from './ProjectTypes';
+import { Logger } from '../Logger';
 
 function findDirectories(directory: string): string[] {
   try {
     return klawSync(directory, { nofile: true }).map((x) => x.path);
   } catch (err) {
-    winston.error(`ProjectLoader: Attempted to find directories in ${directory} failed due to issue: ${err.message}`);
+    Logger.error(`ProjectLoader: Attempted to find directories in ${directory} failed due to issue: ${err.message}`);
   }
   return [];
 }
@@ -34,7 +34,7 @@ async function findProjects(directories: string | string[]): Promise<MetaEdProje
         }
       }
     } catch (err) {
-      winston.error(`ProjectLoader: Attempted load of ${packageToTry} failed due to issue: ${err.message}`);
+      Logger.error(`ProjectLoader: Attempted load of ${packageToTry} failed due to issue: ${err.message}`);
     }
   }
   projects.forEach((p: MetaEdProjectPathPairs) => {
@@ -52,8 +52,8 @@ export function overrideProjectNameAndNamespace(projects: MetaEdProjectPathPairs
     if (projects[index].project.projectName === projectName) return;
 
     const namespaceName = deriveNamespaceFromProjectName(projectName) || '';
-    winston.info(`Overriding projectName: ${projects[index].project.projectName} ${chalk.red('->')} ${projectName}`);
-    winston.info(`Overriding namespaceName: ${projects[index].project.namespaceName} ${chalk.red('->')} ${namespaceName}`);
+    Logger.info(`Overriding projectName: ${projects[index].project.projectName} ${chalk.red('->')} ${projectName}`);
+    Logger.info(`Overriding namespaceName: ${projects[index].project.namespaceName} ${chalk.red('->')} ${namespaceName}`);
 
     projects[index].project.projectName = projectName;
     projects[index].project.namespaceName = namespaceName;

--- a/packages/metaed-odsapi-deploy/src/metaed-odsapi-deploy.ts
+++ b/packages/metaed-odsapi-deploy/src/metaed-odsapi-deploy.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import path from 'path';
-import winston from 'winston';
 import Yargs from 'yargs';
 import {
   scanForProjects,
@@ -19,6 +18,7 @@ import {
   MetaEdEnvironment,
   MetaEdProjectPathPairs,
   MetaEdProject,
+  Logger,
 } from '@edfi/metaed-core';
 import { execute as DeployCore } from './task/DeployCore';
 import { execute as DeployCoreV2 } from './task/DeployCoreV2';
@@ -32,8 +32,6 @@ import { execute as RefreshProject } from './task/RefreshProject';
 import { execute as RemoveExtensionArtifacts } from './task/RemoveExtensionArtifacts';
 import { execute as RemoveExtensionArtifactsV2andV3 } from './task/RemoveExtensionArtifactsV2andV3';
 
-winston.configure({ transports: [new winston.transports.Console()], format: winston.format.cli() });
-
 export function dataStandardVersionFor(projects: MetaEdProject[]): SemVer {
   const dataStandardVersions: SemVer[] = findDataStandardVersions(projects);
   const errorMessage: string[] = [];
@@ -46,7 +44,7 @@ export function dataStandardVersionFor(projects: MetaEdProject[]): SemVer {
     return dataStandardVersions[0];
   }
   if (errorMessage.length > 0) {
-    errorMessage.forEach((err) => winston.error(err));
+    errorMessage.forEach((err) => Logger.error(err));
     process.exit(1);
   }
   return '0.0.0';
@@ -137,7 +135,7 @@ export async function metaEdDeploy() {
       const { failure } = await executePipeline(state);
       process.exitCode = !state.validationFailure.some((vf) => vf.category === 'error') && !failure ? 0 : 1;
     } catch (error) {
-      winston.error(error);
+      Logger.error(error);
       process.exitCode = 1;
     }
   } else {
@@ -175,10 +173,10 @@ export async function metaEdDeploy() {
       if (!success) process.exitCode = 1;
     }
   } catch (error) {
-    winston.error(error);
+    Logger.error(error);
     process.exitCode = 1;
   }
 
   const endTime = Date.now() - startTime;
-  winston.info(`Done in ${chalk.green(endTime > 1000 ? `${endTime / 1000}s` : `${endTime}ms`)}.`);
+  Logger.info(`Done in ${chalk.green(endTime > 1000 ? `${endTime / 1000}s` : `${endTime}ms`)}.`);
 }

--- a/packages/metaed-odsapi-deploy/src/task/DeployCore.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployCore.ts
@@ -1,8 +1,7 @@
-import { MetaEdConfiguration } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration } from '@edfi/metaed-core';
 import { versionSatisfies } from '@edfi/metaed-core';
 import fs from 'fs-extra';
 import path from 'path';
-import winston from 'winston';
 import { CopyOptions } from '../CopyOptions';
 
 const corePath: string = 'Ed-Fi-ODS/Application/EdFi.Ods.Standard/Artifacts';
@@ -30,11 +29,11 @@ function deployCoreArtifacts(metaEdConfiguration: MetaEdConfiguration) {
 
     try {
       const relativeArtifactSource = path.relative(artifactDirectory, resolvedArtifact.src);
-      winston.info(`Deploy ${relativeArtifactSource} to ${artifact.dest}`);
+      Logger.info(`Deploy ${relativeArtifactSource} to ${artifact.dest}`);
 
       fs.copySync(resolvedArtifact.src, resolvedArtifact.dest, resolvedArtifact.options);
     } catch (err) {
-      winston.error(`Attempted deploy of ${artifact.src} failed due to issue: ${err.message}`);
+      Logger.error(`Attempted deploy of ${artifact.src} failed due to issue: ${err.message}`);
     }
   });
 }

--- a/packages/metaed-odsapi-deploy/src/task/DeployCoreV2.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployCoreV2.ts
@@ -1,8 +1,7 @@
-import { MetaEdConfiguration, V2Only } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration, V2Only } from '@edfi/metaed-core';
 import { versionSatisfies } from '@edfi/metaed-core';
 import fs from 'fs-extra';
 import path from 'path';
-import winston from 'winston';
 import { CopyOptions } from '../CopyOptions';
 
 /* eslint-disable prettier/prettier */
@@ -29,11 +28,11 @@ function deployCoreArtifacts(metaEdConfiguration: MetaEdConfiguration) {
 
     try {
       const relativeArtifactSource = path.relative(artifactDirectory, resolvedArtifact.src);
-      winston.info(`Deploy ${relativeArtifactSource} to ${artifact.dest}`);
+      Logger.info(`Deploy ${relativeArtifactSource} to ${artifact.dest}`);
 
       fs.copySync(resolvedArtifact.src, resolvedArtifact.dest, resolvedArtifact.options);
     } catch (err) {
-      winston.error(`Attempted deploy of ${resolvedArtifact.src} failed due to issue: ${err.message}`);
+      Logger.error(`Attempted deploy of ${resolvedArtifact.src} failed due to issue: ${err.message}`);
     }
   });
 }

--- a/packages/metaed-odsapi-deploy/src/task/DeployCoreV3.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployCoreV3.ts
@@ -1,8 +1,7 @@
-import { MetaEdConfiguration } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration } from '@edfi/metaed-core';
 import { versionSatisfies } from '@edfi/metaed-core';
 import fs from 'fs-extra';
 import path from 'path';
-import winston from 'winston';
 import { CopyOptions } from '../CopyOptions';
 
 const excludeApiModel = (_src: string, dest: string): boolean => !dest.endsWith('ApiModel.json');
@@ -32,11 +31,11 @@ function deployCoreArtifacts(metaEdConfiguration: MetaEdConfiguration) {
 
     try {
       const relativeArtifactSource = path.relative(artifactDirectory, resolvedArtifact.src);
-      winston.info(`Deploy ${relativeArtifactSource} to ${artifact.dest}`);
+      Logger.info(`Deploy ${relativeArtifactSource} to ${artifact.dest}`);
 
       fs.copySync(resolvedArtifact.src, resolvedArtifact.dest, resolvedArtifact.options);
     } catch (err) {
-      winston.error(`Attempted deploy of ${artifact.src} failed due to issue: ${err.message}`);
+      Logger.error(`Attempted deploy of ${artifact.src} failed due to issue: ${err.message}`);
     }
   });
 }

--- a/packages/metaed-odsapi-deploy/src/task/DeployExtension.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployExtension.ts
@@ -1,8 +1,6 @@
 import fs from 'fs-extra';
-import { MetaEdConfiguration } from '@edfi/metaed-core';
-import { versionSatisfies } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration, versionSatisfies } from '@edfi/metaed-core';
 import path from 'path';
-import winston from 'winston';
 import Sugar from 'sugar';
 import { CopyOptions } from '../CopyOptions';
 
@@ -34,11 +32,11 @@ function deployExtensionArtifacts(metaEdConfiguration: MetaEdConfiguration): voi
       if (!fs.pathExistsSync(resolvedArtifact.src)) return;
 
       try {
-        winston.info(`Deploy ${resolvedArtifact.src} to ${resolvedArtifact.dest}`);
+        Logger.info(`Deploy ${resolvedArtifact.src} to ${resolvedArtifact.dest}`);
 
         fs.copySync(resolvedArtifact.src, resolvedArtifact.dest, resolvedArtifact.options);
       } catch (err) {
-        winston.error(`Attempted deploy of ${artifact.src} failed due to issue: ${err.message}`);
+        Logger.error(`Attempted deploy of ${artifact.src} failed due to issue: ${err.message}`);
       }
     });
   });

--- a/packages/metaed-odsapi-deploy/src/task/DeployExtensionV2.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployExtensionV2.ts
@@ -1,8 +1,6 @@
 import fs from 'fs-extra';
-import { MetaEdConfiguration, V2Only } from '@edfi/metaed-core';
-import { versionSatisfies } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration, V2Only, versionSatisfies } from '@edfi/metaed-core';
 import path from 'path';
-import winston from 'winston';
 import { CopyOptions } from '../CopyOptions';
 
 const artifacts: CopyOptions[] = [
@@ -29,11 +27,11 @@ function deployExtensionArtifacts(metaEdConfiguration: MetaEdConfiguration): voi
       if (!fs.pathExistsSync(resolvedArtifact.src)) return;
 
       try {
-        winston.info(`Deploy ${resolvedArtifact.src} to ${resolvedArtifact.dest}`);
+        Logger.info(`Deploy ${resolvedArtifact.src} to ${resolvedArtifact.dest}`);
 
         fs.copySync(resolvedArtifact.src, resolvedArtifact.dest, resolvedArtifact.options);
       } catch (err) {
-        winston.error(`Attempted deploy of ${artifact.src} failed due to issue: ${err.message}`);
+        Logger.error(`Attempted deploy of ${artifact.src} failed due to issue: ${err.message}`);
       }
     });
   });

--- a/packages/metaed-odsapi-deploy/src/task/DeployExtensionV3.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployExtensionV3.ts
@@ -1,8 +1,7 @@
 import fs from 'fs-extra';
-import { MetaEdConfiguration } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration } from '@edfi/metaed-core';
 import { versionSatisfies } from '@edfi/metaed-core';
 import path from 'path';
-import winston from 'winston';
 import Sugar from 'sugar';
 import { CopyOptions } from '../CopyOptions';
 
@@ -32,11 +31,11 @@ function deployExtensionArtifacts(metaEdConfiguration: MetaEdConfiguration): voi
       if (!fs.pathExistsSync(resolvedArtifact.src)) return;
 
       try {
-        winston.info(`Deploy ${resolvedArtifact.src} to ${resolvedArtifact.dest}`);
+        Logger.info(`Deploy ${resolvedArtifact.src} to ${resolvedArtifact.dest}`);
 
         fs.copySync(resolvedArtifact.src, resolvedArtifact.dest, resolvedArtifact.options);
       } catch (err) {
-        winston.error(`Attempted deploy of ${artifact.src} failed due to issue: ${err.message}`);
+        Logger.error(`Attempted deploy of ${artifact.src} failed due to issue: ${err.message}`);
       }
     });
   });

--- a/packages/metaed-odsapi-deploy/src/task/ExtensionProjectsExists.ts
+++ b/packages/metaed-odsapi-deploy/src/task/ExtensionProjectsExists.ts
@@ -1,8 +1,7 @@
-import { MetaEdConfiguration, versionSatisfies } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration, versionSatisfies } from '@edfi/metaed-core';
 import fs from 'fs-extra';
 import path from 'path';
 import Sugar from 'sugar';
-import winston from 'winston';
 
 const projectPaths: string[] = ['Ed-Fi-ODS-Implementation/Application/EdFi.Ods.Extensions.{projectName}/'];
 
@@ -19,7 +18,7 @@ export function extensionProjectsExists(metaEdConfiguration: MetaEdConfiguration
       const resolvedPath = path.resolve(deployDirectory, Sugar.String.format(projectPath, { projectName }));
       if (fs.pathExistsSync(resolvedPath)) return;
 
-      winston.error(`Expected ${projectName} project but was not at path: ${resolvedPath}`);
+      Logger.error(`Expected ${projectName} project but was not at path: ${resolvedPath}`);
       result = false;
     });
   });

--- a/packages/metaed-odsapi-deploy/src/task/LegacyDirectoryExists.ts
+++ b/packages/metaed-odsapi-deploy/src/task/LegacyDirectoryExists.ts
@@ -1,7 +1,6 @@
-import { MetaEdConfiguration, versionSatisfies } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration, versionSatisfies } from '@edfi/metaed-core';
 import fs from 'fs-extra';
 import path from 'path';
-import winston from 'winston';
 
 export function legacyCoreDirectoryExists(metaEdConfiguration: MetaEdConfiguration): void {
   const { deployDirectory } = metaEdConfiguration;
@@ -11,7 +10,7 @@ export function legacyCoreDirectoryExists(metaEdConfiguration: MetaEdConfigurati
     const resolvedPath = path.resolve(deployDirectory, legacyPath);
 
     if (fs.pathExistsSync(resolvedPath)) {
-      winston.warn(
+      Logger.warn(
         `"SupportingArtifacts" directory found for Standard at ${resolvedPath}.  Please move any custom artifacts to the new "Artifact" directory and remove the "SupportingArtifacts" directory.`,
       );
     }
@@ -33,7 +32,7 @@ export function legacyExtensionDirectoryExists(metaEdConfiguration: MetaEdConfig
       const resolvedPath = path.resolve(deployDirectory, legacyPath);
 
       if (fs.pathExistsSync(resolvedPath)) {
-        winston.warn(
+        Logger.warn(
           `"SupportingArtifacts" directory found for ${projectName} at ${resolvedPath}.  Please move any custom artifacts to the new "Artifact" directory and remove the "SupportingArtifacts" directory.`,
         );
       }

--- a/packages/metaed-odsapi-deploy/src/task/RefreshProject.ts
+++ b/packages/metaed-odsapi-deploy/src/task/RefreshProject.ts
@@ -1,10 +1,9 @@
-import { MetaEdConfiguration } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration } from '@edfi/metaed-core';
 import chalk from 'chalk';
 import fs from 'fs-extra';
 import touch from 'touch';
 import path from 'path';
 import Sugar from 'sugar';
-import winston from 'winston';
 
 const projectPaths: string[] = [
   'Ed-Fi-ODS-Implementation/Application/EdFi.Ods.Extensions.{projectName}/EdFi.Ods.Extensions.{projectName}.csproj',
@@ -22,11 +21,11 @@ export function refreshProject(metaEdConfiguration: MetaEdConfiguration): void {
       if (!fs.pathExistsSync(resolvedPath)) return;
 
       try {
-        winston.info(`Refresh ${resolvedPath}`);
+        Logger.info(`Refresh ${resolvedPath}`);
 
         touch.sync(resolvedPath, { nocreate: true });
       } catch (err) {
-        winston.error(`Attempted modification of ${chalk.red(resolvedPath)} failed due to issue: ${err.message}`);
+        Logger.error(`Attempted modification of ${chalk.red(resolvedPath)} failed due to issue: ${err.message}`);
       }
     });
   });

--- a/packages/metaed-odsapi-deploy/src/task/RemoveExtensionArtifacts.ts
+++ b/packages/metaed-odsapi-deploy/src/task/RemoveExtensionArtifacts.ts
@@ -1,7 +1,6 @@
-import { MetaEdConfiguration, versionSatisfies } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration, versionSatisfies } from '@edfi/metaed-core';
 import fs from 'fs-extra';
 import path from 'path';
-import winston from 'winston';
 
 export function removeExtensionArtifacts(metaEdConfiguration: MetaEdConfiguration): boolean {
   const { artifactDirectory, deployDirectory } = metaEdConfiguration;
@@ -17,11 +16,11 @@ export function removeExtensionArtifacts(metaEdConfiguration: MetaEdConfiguratio
       if (!fs.pathExistsSync(resolvedPath)) return;
 
       try {
-        winston.info(`Remove ${projectName} artifacts ${resolvedPath}`);
+        Logger.info(`Remove ${projectName} artifacts ${resolvedPath}`);
 
         fs.removeSync(resolvedPath);
       } catch (err) {
-        winston.error(`Attempted removal of ${resolvedPath} failed due to issue: ${err.message}`);
+        Logger.error(`Attempted removal of ${resolvedPath} failed due to issue: ${err.message}`);
         result = false;
       }
     });

--- a/packages/metaed-odsapi-deploy/src/task/RemoveExtensionArtifactsV2andV3.ts
+++ b/packages/metaed-odsapi-deploy/src/task/RemoveExtensionArtifactsV2andV3.ts
@@ -1,7 +1,6 @@
-import { MetaEdConfiguration, versionSatisfies } from '@edfi/metaed-core';
+import { Logger, MetaEdConfiguration, versionSatisfies } from '@edfi/metaed-core';
 import fs from 'fs-extra';
 import path from 'path';
-import winston from 'winston';
 
 export function removeExtensionArtifacts(metaEdConfiguration: MetaEdConfiguration): boolean {
   const { artifactDirectory, deployDirectory } = metaEdConfiguration;
@@ -21,11 +20,11 @@ export function removeExtensionArtifacts(metaEdConfiguration: MetaEdConfiguratio
       if (!fs.pathExistsSync(resolvedPath)) return;
 
       try {
-        winston.info(`Remove ${projectName} artifacts ${resolvedPath}`);
+        Logger.info(`Remove ${projectName} artifacts ${resolvedPath}`);
 
         fs.removeSync(resolvedPath);
       } catch (err) {
-        winston.error(`Attempted removal of ${resolvedPath} failed due to issue: ${err.message}`);
+        Logger.error(`Attempted removal of ${resolvedPath} failed due to issue: ${err.message}`);
         result = false;
       }
     });

--- a/packages/metaed-plugin-edfi-ods-postgresql/test/database/DatabaseTestBase.ts
+++ b/packages/metaed-plugin-edfi-ods-postgresql/test/database/DatabaseTestBase.ts
@@ -1,8 +1,7 @@
-import winston from 'winston';
 import { Client } from 'pg';
 import pgStructure, { Db } from 'pg-structure';
 
-import { MetaEdEnvironment } from '@edfi/metaed-core';
+import { Logger, MetaEdEnvironment } from '@edfi/metaed-core';
 import { initialize as initializeUnifiedPlugin } from '@edfi/metaed-plugin-edfi-unified';
 import { initialize as initializeOdsRelationalPlugin } from '@edfi/metaed-plugin-edfi-ods-relational';
 import { initialize as initializeOdsPostgresqlPlugin } from '../../index';
@@ -10,9 +9,6 @@ import { generate as odsGenerate } from '../../src/generator/OdsGenerator';
 import { generate as schemaGenerate } from '../../src/generator/SchemaGenerator';
 
 export const testDatabaseName = 'metaed_integration_tests';
-
-winston.configure({ transports: [new winston.transports.Console()], format: winston.format.cli() });
-winston.level = 'info';
 
 let client: Client | null = null;
 
@@ -25,7 +21,7 @@ export const testDbDefinition = {
 };
 
 async function executeGeneratedSql(generatedSql: string): Promise<Db | null> {
-  winston.verbose(`[${testDatabaseName}] executeGeneratedSql`);
+  Logger.verbose(`[${testDatabaseName}] executeGeneratedSql`);
   try {
     client = new Client(testDbDefinition);
     await client.connect();
@@ -40,7 +36,7 @@ async function executeGeneratedSql(generatedSql: string): Promise<Db | null> {
     await client.query(generatedSql);
     return await pgStructure(client);
   } catch (error) {
-    winston.verbose(`[${testDatabaseName}] executeGeneratedSql: ${error.message} ${error.stack}`);
+    Logger.verbose(`[${testDatabaseName}] executeGeneratedSql: ${error.message} ${error.stack}`);
     return null;
   }
 }
@@ -49,7 +45,7 @@ export async function testSuiteAfterAll() {
   try {
     if (client != null) await client.end();
   } catch (error) {
-    winston.verbose(`[${testDatabaseName}] testSuiteAfterAll: ${error.message} ${error.stack}`);
+    Logger.verbose(`[${testDatabaseName}] testSuiteAfterAll: ${error.message} ${error.stack}`);
   }
 }
 
@@ -57,7 +53,7 @@ export async function testAfterEach() {
   try {
     if (client != null) await client.query('ROLLBACK');
   } catch (error) {
-    winston.verbose(`[${testDatabaseName}] testSuiteAfterAll: ${error.message} ${error.stack}`);
+    Logger.verbose(`[${testDatabaseName}] testSuiteAfterAll: ${error.message} ${error.stack}`);
   }
 }
 

--- a/packages/metaed-plugin-edfi-ods-relational/src/model/database/Column.ts
+++ b/packages/metaed-plugin-edfi-ods-relational/src/model/database/Column.ts
@@ -1,7 +1,6 @@
 import deepFreeze from 'deep-freeze';
 import R from 'ramda';
-import winston from 'winston';
-import { EntityProperty, TopLevelEntity } from '@edfi/metaed-core';
+import { EntityProperty, Logger, TopLevelEntity } from '@edfi/metaed-core';
 import { ColumnType } from './ColumnType';
 import { NoTable, Table } from './Table';
 
@@ -225,7 +224,7 @@ export function addSourceEntityProperty(column: Column, property: EntityProperty
   if (existingProperty == null) {
     column.sourceEntityProperties.push(property);
   } else {
-    winston.warn(
+    Logger.warn(
       `  Attempt to add duplicate source entity property: ${property.metaEdName} (${property.typeHumanizedName})  to column ${column.columnId} failed.`,
     );
   }

--- a/packages/metaed-plugin-edfi-ods-relational/src/model/database/ForeignKey.ts
+++ b/packages/metaed-plugin-edfi-ods-relational/src/model/database/ForeignKey.ts
@@ -1,6 +1,12 @@
 import R from 'ramda';
-import winston from 'winston';
-import { orderByProp, asCommonProperty, NoNamespace, DomainEntityProperty, AssociationProperty } from '@edfi/metaed-core';
+import {
+  orderByProp,
+  asCommonProperty,
+  NoNamespace,
+  DomainEntityProperty,
+  AssociationProperty,
+  Logger,
+} from '@edfi/metaed-core';
 import { EntityProperty, PropertyType, Namespace } from '@edfi/metaed-core';
 import { ReferencePropertyEdfiOds } from '../property/ReferenceProperty';
 import { NoTable, getPrimaryKeys, getColumn } from './Table';
@@ -132,7 +138,7 @@ export function addColumnPair(foreignKey: ForeignKey, columnPair: ColumnPair): v
   if (existingPair == null) {
     foreignKey.columnPairs.push(columnPair);
   } else {
-    winston.debug(
+    Logger.debug(
       `  Attempt to add duplicate column pair: [${columnPair.parentTableColumnId}, ${columnPair.foreignTableColumnId}] on foreign key referencing ${foreignKey.foreignTableSchema}.${foreignKey.foreignTableId} failed.`,
     );
   }

--- a/packages/metaed-plugin-edfi-ods-relational/src/model/database/Table.ts
+++ b/packages/metaed-plugin-edfi-ods-relational/src/model/database/Table.ts
@@ -1,6 +1,5 @@
 import deepFreeze from 'deep-freeze';
 import R from 'ramda';
-import winston from 'winston';
 import {
   orderByProp,
   NoTopLevelEntity,
@@ -9,6 +8,7 @@ import {
   TopLevelEntity,
   EntityProperty,
   Namespace,
+  Logger,
 } from '@edfi/metaed-core';
 import { columnConstraintMerge, Column, NoColumn } from './Column';
 import { ColumnTransform } from './ColumnTransform';
@@ -218,7 +218,7 @@ export function getColumnWithStrongestConstraint(
   const existingColumn = table.columns.find((x) => x.columnId === column.columnId);
   if (existingColumn == null) return column;
 
-  winston.debug(`  Duplicate column ${column.columnId} on table ${simpleTableNameGroupConcat(table.nameGroup)}.`);
+  Logger.debug(`  Duplicate column ${column.columnId} on table ${simpleTableNameGroupConcat(table.nameGroup)}.`);
   table.columns = R.reject((c: Column) => c.columnId === column.columnId)(table.columns);
   return constraintStrategy(existingColumn, column);
 }

--- a/packages/metaed-plugin-edfi-ods-sqlserver/test/database/DatabaseConnection.ts
+++ b/packages/metaed-plugin-edfi-ods-sqlserver/test/database/DatabaseConnection.ts
@@ -1,11 +1,9 @@
-import winston from 'winston';
+import { Logger } from '@edfi/metaed-core';
 import { highlight } from 'cli-highlight';
 import sql from 'mssql';
 
 export const testDatabaseName = 'MetaEd_Ods_Integration_Tests';
 
-winston.configure({ transports: [new winston.transports.Console()], format: winston.format.cli() });
-winston.level = 'info';
 const highlightSql = (statement: string) => highlight(statement, { language: 'sql', ignoreIllegals: true });
 
 export interface Pool {
@@ -40,16 +38,16 @@ export async function disconnect(databaseName: string): Promise<void> {
       if (pool != null) {
         if (pool.transaction != null) {
           await pool.transaction.rollback();
-          winston.verbose(`[${databaseName}] DatabaseConnection.disconnect: rolling back transaction`);
+          Logger.verbose(`[${databaseName}] DatabaseConnection.disconnect: rolling back transaction`);
         }
         if (pool.connection != null) {
           await pool.connection.close();
-          winston.verbose(`[${databaseName}] DatabaseConnection.disconnect: pool disconnected.`);
+          Logger.verbose(`[${databaseName}] DatabaseConnection.disconnect: pool disconnected.`);
         }
         pools.delete(databaseName);
       }
     } catch (error) {
-      winston.verbose(`[${databaseName}] DatabaseConnection.disconnect: ${error.message} ${error.stack}`);
+      Logger.verbose(`[${databaseName}] DatabaseConnection.disconnect: ${error.message} ${error.stack}`);
     }
   }
 }
@@ -70,14 +68,14 @@ export async function connect(databaseName: string, retry: number = retryCount):
   let pool: Pool = {};
   try {
     pool.connection = await new sql.ConnectionPool({ ...newConfig, database: databaseName });
-    winston.verbose(`[${databaseName}] created connection pool`);
+    Logger.verbose(`[${databaseName}] created connection pool`);
     if (!pool.connection.connected && !pool.connection.connecting) {
       await pool.connection.connect();
     }
 
     pool.transaction = await new sql.Transaction(pool.connection);
     await pool.transaction.begin();
-    winston.verbose(`[${databaseName}] ---------- begin transaction ----------`);
+    Logger.verbose(`[${databaseName}] ---------- begin transaction ----------`);
   } catch (error) {
     // NOTE: This is a work around for the following error. This seems to occur most often when a fresh database has been
     // created and a connection attempt is made while it is in transition.
@@ -103,7 +101,7 @@ export async function database(databaseName: string, fn: Function, transaction: 
       throw new Error('DatabaseConnection: Pool had no connection or transaction');
     }
   } catch (error) {
-    winston.error(`[${databaseName}] ${error.message} ${error.stack}`);
+    Logger.error(`[${databaseName}] ${error.message} ${error.stack}`);
   }
 }
 
@@ -111,7 +109,7 @@ export async function beginTransaction(databaseName: string): Promise<void> {
   if (pools.has(databaseName)) {
     const pool = pools.get(databaseName);
     if (pool != null && pool.transaction != null) {
-      winston.verbose(`[${databaseName}] DatabaseConnection.beginTransaction: beginning transaction`);
+      Logger.verbose(`[${databaseName}] DatabaseConnection.beginTransaction: beginning transaction`);
       await pool.transaction.begin();
     }
   }
@@ -121,7 +119,7 @@ export async function rollbackTransaction(databaseName: string): Promise<void> {
   if (pools.has(databaseName)) {
     const pool = pools.get(databaseName);
     if (pool != null && pool.transaction != null) {
-      winston.verbose(`[${databaseName}] DatabaseConnection.rollbackTransaction: rolling back transaction`);
+      Logger.verbose(`[${databaseName}] DatabaseConnection.rollbackTransaction: rolling back transaction`);
       await pool.transaction.rollback();
     }
   }
@@ -129,10 +127,10 @@ export async function rollbackTransaction(databaseName: string): Promise<void> {
 
 export async function query(connection: sql.Connection | sql.Transaction, action: string, statement: string): Promise<any> {
   const databaseName: string = connection.config ? connection.config.database : connection.parent.config.database;
-  winston.verbose(`[${databaseName}] ${action}`);
-  winston.verbose('\n', highlightSql(statement));
+  Logger.verbose(`[${databaseName}] ${action}`);
+  Logger.verbose(`\n${highlightSql(statement)}`);
   const result = await new sql.Request(connection).query(statement);
-  winston.verbose(`=> `, result.recordset);
+  Logger.verbose(`=> ${result.recordset}`);
   return result.recordset;
 }
 
@@ -159,10 +157,10 @@ export async function executeGeneratedSql(generatedSql: string, databaseName: st
   await database(
     databaseName,
     async (db) => {
-      winston.verbose(`[${databaseName}] executeGeneratedSql`);
+      Logger.verbose(`[${databaseName}] executeGeneratedSql`);
       // eslint-disable-next-line no-restricted-syntax
       for (const statement of sqlStatements) {
-        winston.debug('\n', highlightSql(statement));
+        Logger.debug('\n', highlightSql(statement));
         if (statement != null || statement !== '') await new sql.Request(db).query(statement);
       }
     },

--- a/packages/metaed-plugin-edfi-ods-sqlserver/test/database/InitializeOdsIntegrationTestDatabase.ts
+++ b/packages/metaed-plugin-edfi-ods-sqlserver/test/database/InitializeOdsIntegrationTestDatabase.ts
@@ -1,7 +1,5 @@
-import winston from 'winston';
+import { Logger } from '@edfi/metaed-core';
 import { database, query, disconnect, testDatabaseName } from './DatabaseConnection';
-
-winston.configure({ transports: [new winston.transports.Console()], format: winston.format.cli() });
 
 async function dropDatabaseIfExists(databaseName: string): Promise<void> {
   const sql = `
@@ -49,5 +47,5 @@ CREATE DATABASE [${databaseName}]
   await createDatabaseIfNotExists(testDatabaseName);
   await disconnect('master');
 })().catch((e) => {
-  winston.error(`InitializeTestDatabase: ${e.message} ${e.stack}`);
+  Logger.error(`InitializeTestDatabase: ${e.message} ${e.stack}`);
 });

--- a/packages/metaed-plugin-edfi-odsapi/src/enhancer/interchangeOrderMetadata/InterchangeOrderMetadataEnhancer.ts
+++ b/packages/metaed-plugin-edfi-odsapi/src/enhancer/interchangeOrderMetadata/InterchangeOrderMetadataEnhancer.ts
@@ -1,4 +1,3 @@
-import winston from 'winston';
 import { uniq, sortWith, prop } from 'ramda';
 import {
   isReferentialProperty,
@@ -6,6 +5,7 @@ import {
   asChoiceProperty,
   asReferentialProperty,
   NoInterchangeItem,
+  Logger,
 } from '@edfi/metaed-core';
 import {
   ChoiceProperty,
@@ -112,7 +112,7 @@ export function sortGraph(graph: Graph, removeRequiredCycles: boolean = false): 
 
   if (graphlib.alg.isAcyclic(graph)) return graphlib.alg.topsort(graph);
 
-  winston.error('Unable to sort interchange metadata');
+  Logger.error('Unable to sort interchange metadata');
   return [];
 }
 


### PR DESCRIPTION
When researching for [RND-441](https://tracker.ed-fi.org/browse/RND-441), one of the reasons for the error is that winston is being used directly and the transport is configured per file only, and not all files have the configuration.

This is an attempt to create a common Logger, based on the one from Meadowlark.
This is a work in progress and needs more research / tests.

Feel free to close, redo or take over if valuable.

Aspects yet to be defined:
- How to handle the Logger initialization?
- How to test the changes?

This is not affecting any of the atom packages, regardless, this should be done after that effort is completed.