### PR TITLE
[METAED-1302] Removes dependencies to @edfi/ed-fi-model-2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1027,14 +1027,6 @@
       "integrity": "sha1-vLgI0jH1J94RP0tM6Aoxv1e/h1c=",
       "license": "BSD"
     },
-    "node_modules/@edfi/ed-fi-model-2.0": {
-      "version": "3.0.1",
-      "license": "private"
-    },
-    "node_modules/@edfi/ed-fi-model-2.2": {
-      "version": "3.0.1",
-      "license": "private"
-    },
     "node_modules/@edfi/ed-fi-model-3.0": {
       "version": "3.0.1",
       "license": "private"
@@ -16072,8 +16064,6 @@
       "version": "4.0.1-dev.17",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
-        "@edfi/ed-fi-model-2.2": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -16375,7 +16365,6 @@
         "sugar": "^2.0.6"
       },
       "devDependencies": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -16437,7 +16426,6 @@
         "sugar": "^2.0.6"
       },
       "devDependencies": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -16460,7 +16448,6 @@
         "sugar": "^2.0.6"
       },
       "devDependencies": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -16490,7 +16477,6 @@
         "sugar": "^2.0.6"
       },
       "devDependencies": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -16570,7 +16556,6 @@
         "xml-js": "^1.6.11"
       },
       "devDependencies": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -17262,12 +17247,6 @@
       "resolved": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/@edfi/antlr4/-/antlr4-4.6.1.tgz",
       "integrity": "sha1-vLgI0jH1J94RP0tM6Aoxv1e/h1c="
     },
-    "@edfi/ed-fi-model-2.0": {
-      "version": "3.0.1"
-    },
-    "@edfi/ed-fi-model-2.2": {
-      "version": "3.0.1"
-    },
     "@edfi/ed-fi-model-3.0": {
       "version": "3.0.1"
     },
@@ -17298,8 +17277,6 @@
     "@edfi/metaed-console": {
       "version": "file:packages/metaed-console",
       "requires": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
-        "@edfi/ed-fi-model-2.2": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -17519,7 +17496,6 @@
     "@edfi/metaed-plugin-edfi-ods-postgresql": {
       "version": "file:packages/metaed-plugin-edfi-ods-postgresql",
       "requires": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -17573,7 +17549,6 @@
     "@edfi/metaed-plugin-edfi-ods-relational": {
       "version": "file:packages/metaed-plugin-edfi-ods-relational",
       "requires": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -17591,7 +17566,6 @@
     "@edfi/metaed-plugin-edfi-ods-sqlserver": {
       "version": "file:packages/metaed-plugin-edfi-ods-sqlserver",
       "requires": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -17614,7 +17588,6 @@
       "version": "file:packages/metaed-plugin-edfi-odsapi",
       "requires": {
         "@dagrejs/graphlib": "^2.1.4",
-        "@edfi/ed-fi-model-2.0": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",
@@ -17681,7 +17654,6 @@
     "@edfi/metaed-plugin-edfi-xsd": {
       "version": "file:packages/metaed-plugin-edfi-xsd",
       "requires": {
-        "@edfi/ed-fi-model-2.0": "3.0.1",
         "@edfi/ed-fi-model-3.0": "3.0.1",
         "@edfi/ed-fi-model-3.1": "3.0.1",
         "@edfi/ed-fi-model-3.2a": "3.0.1",

--- a/packages/metaed-console/package.json
+++ b/packages/metaed-console/package.json
@@ -14,8 +14,6 @@
     "/package.json"
   ],
   "dependencies": {
-    "@edfi/ed-fi-model-2.0": "3.0.1",
-    "@edfi/ed-fi-model-2.2": "3.0.1",
     "@edfi/ed-fi-model-3.0": "3.0.1",
     "@edfi/ed-fi-model-3.1": "3.0.1",
     "@edfi/ed-fi-model-3.2a": "3.0.1",

--- a/packages/metaed-plugin-edfi-ods-postgresql/package.json
+++ b/packages/metaed-plugin-edfi-ods-postgresql/package.json
@@ -26,7 +26,6 @@
     "sugar": "^2.0.6"
   },
   "devDependencies": {
-    "@edfi/ed-fi-model-2.0": "3.0.1",
     "@edfi/ed-fi-model-3.0": "3.0.1",
     "@edfi/ed-fi-model-3.1": "3.0.1",
     "@edfi/ed-fi-model-3.2a": "3.0.1",

--- a/packages/metaed-plugin-edfi-ods-relational/package.json
+++ b/packages/metaed-plugin-edfi-ods-relational/package.json
@@ -24,7 +24,6 @@
     "sugar": "^2.0.6"
   },
   "devDependencies": {
-    "@edfi/ed-fi-model-2.0": "3.0.1",
     "@edfi/ed-fi-model-3.0": "3.0.1",
     "@edfi/ed-fi-model-3.1": "3.0.1",
     "@edfi/ed-fi-model-3.2a": "3.0.1",

--- a/packages/metaed-plugin-edfi-ods-sqlserver/package.json
+++ b/packages/metaed-plugin-edfi-ods-sqlserver/package.json
@@ -25,7 +25,6 @@
     "sugar": "^2.0.6"
   },
   "devDependencies": {
-    "@edfi/ed-fi-model-2.0": "3.0.1",
     "@edfi/ed-fi-model-3.0": "3.0.1",
     "@edfi/ed-fi-model-3.1": "3.0.1",
     "@edfi/ed-fi-model-3.2a": "3.0.1",

--- a/packages/metaed-plugin-edfi-odsapi/package.json
+++ b/packages/metaed-plugin-edfi-odsapi/package.json
@@ -29,7 +29,6 @@
     "sugar": "^2.0.6"
   },
   "devDependencies": {
-    "@edfi/ed-fi-model-2.0": "3.0.1",
     "@edfi/ed-fi-model-3.0": "3.0.1",
     "@edfi/ed-fi-model-3.1": "3.0.1",
     "@edfi/ed-fi-model-3.2a": "3.0.1",

--- a/packages/metaed-plugin-edfi-xsd/package.json
+++ b/packages/metaed-plugin-edfi-xsd/package.json
@@ -27,7 +27,6 @@
     "xml-js": "^1.6.11"
   },
   "devDependencies": {
-    "@edfi/ed-fi-model-2.0": "3.0.1",
     "@edfi/ed-fi-model-3.0": "3.0.1",
     "@edfi/ed-fi-model-3.1": "3.0.1",
     "@edfi/ed-fi-model-3.2a": "3.0.1",


### PR DESCRIPTION
On the previous commit we forgot to remove these dependencies. 