### PR TITLE
[METAED-1465] Update MetaEd to output folder 5.0.0 as version in generated files

### DIFF
--- a/packages/metaed-odsapi-deploy-console/src/metaed-odsapi-deploy-console.ts
+++ b/packages/metaed-odsapi-deploy-console/src/metaed-odsapi-deploy-console.ts
@@ -109,7 +109,6 @@ export async function metaEdDeploy() {
     .alias('version', 'v');
 
   let metaEdConfiguration: MetaEdConfiguration;
-
   if (yargs.argv['metaEdConfiguration'] == null) {
     // if this function was called outside the normal CLI flow, do nothing and return
     if (yargs.argv['source'] == null || yargs.argv['projectNames'] == null) return;
@@ -118,13 +117,16 @@ export async function metaEdDeploy() {
       yargs.argv['source'],
       yargs.argv['projectNames'],
     );
-
+    let suppressPrereleaseVersion: boolean;
+    if (yargs.argv['suppressPrereleaseVersion'] != null) suppressPrereleaseVersion = yargs.argv['suppressPrereleaseVersion'];
+    else suppressPrereleaseVersion = true;
     metaEdConfiguration = {
       ...newMetaEdConfiguration(),
       artifactDirectory: path.join(resolvedProjects.slice(-1)[0].path, 'MetaEdOutput'),
       deployDirectory: yargs.argv['target'],
       projectPaths: resolvedProjects.map((projectPair: MetaEdProjectPathPairs) => projectPair.path),
       projects: resolvedProjects.map((projectPair: MetaEdProjectPathPairs) => projectPair.project),
+      suppressPrereleaseVersion,
     };
     if (yargs.argv['defaultPluginTechVersion'] != null) {
       metaEdConfiguration.defaultPluginTechVersion = yargs.argv['defaultPluginTechVersion'];
@@ -136,9 +138,6 @@ export async function metaEdDeploy() {
       runGenerators: true,
       stopOnValidationFailure: true,
     };
-    let suppressPrereleaseVersion: boolean;
-    if (yargs.argv['suppressPrereleaseVersion'] != null) suppressPrereleaseVersion = yargs.argv['suppressPrereleaseVersion'];
-    else suppressPrereleaseVersion = true;
     const dataStandardVersion: SemVer = dataStandardVersionFor(metaEdConfiguration.projects);
     const metaEd: MetaEdEnvironment = {
       ...newMetaEdEnvironment(),
@@ -146,7 +145,6 @@ export async function metaEdDeploy() {
       suppressPrereleaseVersion,
     };
     const state: State = { ...newState(), metaEdConfiguration, pipelineOptions, metaEd, metaEdPlugins: defaultPlugins() };
-
     try {
       const { failure } = await executePipeline(state);
       process.exitCode = !state.validationFailure.some((vf) => vf.category === 'error') && !failure ? 0 : 1;

--- a/packages/metaed-odsapi-deploy/src/task/DeployCore.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployCore.ts
@@ -19,12 +19,11 @@ function deployPaths(corePath: string): CopyOptions[] {
 function deployCoreArtifacts(metaEdConfiguration: MetaEdConfiguration, dataStandardVersion: SemVer) {
   const { artifactDirectory, deployDirectory } = metaEdConfiguration;
   const projectName: string = 'EdFi';
-  const versionSatisfiesV7OrGreater = !versionSatisfies(metaEdConfiguration.defaultPluginTechVersion, V7OrGreater);
+  const versionSatisfiesV7OrGreater = versionSatisfies(metaEdConfiguration.defaultPluginTechVersion, V7OrGreater);
   const dataStandardVersionFormatted = versionSatisfiesV7OrGreater
     ? formatVersionWithSuppressPrereleaseVersion(dataStandardVersion, metaEdConfiguration.suppressPrereleaseVersion)
     : dataStandardVersion;
   const corePath: string = `Ed-Fi-ODS/Application/EdFi.Ods.Standard/Standard/${dataStandardVersionFormatted}/Artifacts`;
-
   deployPaths(corePath).forEach((deployPath: CopyOptions) => {
     const resolvedDeployPath: CopyOptions = {
       ...deployPath,

--- a/packages/metaed-odsapi-deploy/src/task/DeployExtension.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployExtension.ts
@@ -28,7 +28,7 @@ function deployExtensionArtifacts(metaEdConfiguration: MetaEdConfiguration, data
   const projectsToDeploy: MetaEdProject[] = projects.filter((p: MetaEdProject) => !isDataStandard(p));
 
   projectsToDeploy.forEach((projectToDeploy: MetaEdProject) => {
-    const versionSatisfiesV7OrGreater = !versionSatisfies(metaEdConfiguration.defaultPluginTechVersion, V7OrGreater);
+    const versionSatisfiesV7OrGreater = versionSatisfies(metaEdConfiguration.defaultPluginTechVersion, V7OrGreater);
     const dataStandardVersionFormatted = versionSatisfiesV7OrGreater
       ? formatVersionWithSuppressPrereleaseVersion(dataStandardVersion, metaEdConfiguration.suppressPrereleaseVersion)
       : dataStandardVersion;


### PR DESCRIPTION
- Update deploy functions to format the datastandard version with the new flag.
- Fix console parameters to suppress prerelease identifier.