### PR TITLE
[METAED-1489] WAIT TO MERGE: new plugin and validator for merge path validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1079,6 +1079,10 @@
       "resolved": "packages/metaed-plugin-edfi-api-schema",
       "link": true
     },
+    "node_modules/@edfi/metaed-plugin-edfi-api-schema-advanced": {
+      "resolved": "packages/metaed-plugin-edfi-api-schema-advanced",
+      "link": true
+    },
     "node_modules/@edfi/metaed-plugin-edfi-handbook": {
       "resolved": "packages/metaed-plugin-edfi-handbook",
       "link": true
@@ -16977,6 +16981,7 @@
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "@edfi/metaed-plugin-edfi-api-schema": "4.2.2-dev.4",
+        "@edfi/metaed-plugin-edfi-api-schema-advanced": "4.2.2-dev.4",
         "@edfi/metaed-plugin-edfi-handbook": "4.2.2-dev.4",
         "@edfi/metaed-plugin-edfi-ods-changequery": "4.2.2-dev.4",
         "@edfi/metaed-plugin-edfi-ods-changequery-postgresql": "4.2.2-dev.4",
@@ -17064,6 +17069,22 @@
         "@edfi/ed-fi-model-5.0-pre.1": "3.0.1",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1"
+      }
+    },
+    "packages/metaed-plugin-edfi-api-schema-advanced": {
+      "name": "@edfi/metaed-plugin-edfi-api-schema-advanced",
+      "version": "4.2.2-dev.4",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@edfi/metaed-core": "4.2.2-dev.4",
+        "@edfi/metaed-plugin-edfi-api-schema": "4.2.2-dev.4",
+        "@edfi/metaed-plugin-edfi-unified": "4.2.2-dev.4",
+        "ts-invariant": "^0.10.3"
+      },
+      "devDependencies": {
+        "@edfi/ed-fi-model-3.3b": "3.0.1",
+        "@edfi/ed-fi-model-4.0": "3.0.1",
+        "@edfi/ed-fi-model-5.0-pre.1": "3.0.1"
       }
     },
     "packages/metaed-plugin-edfi-api-schema/node_modules/ajv": {
@@ -18180,6 +18201,7 @@
       "version": "file:packages/metaed-default-plugins",
       "requires": {
         "@edfi/metaed-plugin-edfi-api-schema": "4.2.2-dev.4",
+        "@edfi/metaed-plugin-edfi-api-schema-advanced": "4.2.2-dev.4",
         "@edfi/metaed-plugin-edfi-handbook": "4.2.2-dev.4",
         "@edfi/metaed-plugin-edfi-ods-changequery": "4.2.2-dev.4",
         "@edfi/metaed-plugin-edfi-ods-changequery-postgresql": "4.2.2-dev.4",
@@ -18269,6 +18291,18 @@
           "version": "1.0.0",
           "dev": true
         }
+      }
+    },
+    "@edfi/metaed-plugin-edfi-api-schema-advanced": {
+      "version": "file:packages/metaed-plugin-edfi-api-schema-advanced",
+      "requires": {
+        "@edfi/ed-fi-model-3.3b": "3.0.1",
+        "@edfi/ed-fi-model-4.0": "3.0.1",
+        "@edfi/ed-fi-model-5.0-pre.1": "3.0.1",
+        "@edfi/metaed-core": "4.2.2-dev.4",
+        "@edfi/metaed-plugin-edfi-api-schema": "4.2.2-dev.4",
+        "@edfi/metaed-plugin-edfi-unified": "4.2.2-dev.4",
+        "ts-invariant": "^0.10.3"
       }
     },
     "@edfi/metaed-plugin-edfi-handbook": {

--- a/packages/metaed-default-plugins/package.json
+++ b/packages/metaed-default-plugins/package.json
@@ -14,6 +14,7 @@
   ],
   "dependencies": {
     "@edfi/metaed-plugin-edfi-api-schema": "4.2.2-dev.4",
+    "@edfi/metaed-plugin-edfi-api-schema-advanced": "4.2.2-dev.4",
     "@edfi/metaed-plugin-edfi-handbook": "4.2.2-dev.4",
     "@edfi/metaed-plugin-edfi-ods-changequery": "4.2.2-dev.4",
     "@edfi/metaed-plugin-edfi-ods-changequery-postgresql": "4.2.2-dev.4",

--- a/packages/metaed-default-plugins/src/index.ts
+++ b/packages/metaed-default-plugins/src/index.ts
@@ -1,6 +1,7 @@
 import type { MetaEdPlugin } from '@edfi/metaed-core';
 
 import { initialize as edfiApiSchema } from '@edfi/metaed-plugin-edfi-api-schema';
+import { initialize as edfiApiSchemaAdvanced } from '@edfi/metaed-plugin-edfi-api-schema-advanced';
 import { initialize as edfiHandbook } from '@edfi/metaed-plugin-edfi-handbook';
 import { initialize as edfiOdsChangequery } from '@edfi/metaed-plugin-edfi-ods-changequery';
 import { initialize as edfiOdsChangequeryPostgresql } from '@edfi/metaed-plugin-edfi-ods-changequery-postgresql';
@@ -31,6 +32,7 @@ export function defaultPlugins(): MetaEdPlugin[] {
     edfiUnifiedAdvanced(),
 
     edfiApiSchema(),
+    edfiApiSchemaAdvanced(),
 
     edfiXsd(),
 

--- a/packages/metaed-plugin-edfi-api-schema-advanced/LICENSE.md
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/LICENSE.md
@@ -1,0 +1,1 @@
+MetaEd is ©2023 Ed-Fi Alliance, LLC. Click [here](https://techdocs.ed-fi.org/x/vRSAAw) for license information.

--- a/packages/metaed-plugin-edfi-api-schema-advanced/index.ts
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/index.ts
@@ -1,0 +1,4 @@
+// Reminder - this index.ts is for on-the-fly transpile when there is no dist directory
+
+// All exports from the "real" index.ts
+export * from './src/index';

--- a/packages/metaed-plugin-edfi-api-schema-advanced/package.json
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@edfi/metaed-plugin-edfi-api-schema-advanced",
+  "main": "dist/index.js",
+  "version": "4.2.2-dev.4",
+  "description": "Advanced MetaEd plugin for generating API Schema object models",
+  "license": "Apache-2.0",
+  "publishConfig": {
+    "registry": "https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/"
+  },
+  "files": [
+    "/dist",
+    "/LICENSE.md",
+    "/package.json"
+  ],
+  "dependencies": {
+    "@edfi/metaed-core": "4.2.2-dev.4",
+    "@edfi/metaed-plugin-edfi-unified": "4.2.2-dev.4",
+    "@edfi/metaed-plugin-edfi-api-schema": "4.2.2-dev.4",
+    "ts-invariant": "^0.10.3"
+  },
+  "devDependencies": {
+    "@edfi/ed-fi-model-3.3b": "3.0.1",
+    "@edfi/ed-fi-model-4.0": "3.0.1",
+    "@edfi/ed-fi-model-5.0-pre.1": "3.0.1"
+  },
+  "scripts": {
+    "build": "npm run build:clean && npm run build:copy-non-ts && npm run build:dist",
+    "build:clean": "rimraf dist",
+    "build:dist": "tsc",
+    "build:copy-non-ts": "copyfiles -u 1 -e \"**/*.ts\" \"src/**/*\" dist --verbose"
+  }
+}

--- a/packages/metaed-plugin-edfi-api-schema-advanced/src/enhancer/README.md
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/src/enhancer/README.md
@@ -1,0 +1,4 @@
+These are MetaEd-style enhancers run on the MetaEd model after the
+model is loaded and the traditional MetaEd pipeline is run on
+the model.  By being designed this way, they can be directly
+brought over into a new MetaEd plugin if we choose.

--- a/packages/metaed-plugin-edfi-api-schema-advanced/src/index.ts
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/src/index.ts
@@ -1,0 +1,17 @@
+import type { MetaEdPlugin } from '@edfi/metaed-core';
+import { enhance as equalityConstraintEnhancer } from './enhancer/EqualityConstraintEnhancer';
+import { enhance as entityApiSchemaAdvancedDataSetupEnhancer } from './model/EntityApiSchemaAdvancedData';
+import { validate as mergeDirectiveMustBeAValidPath } from './validator/MergeDirectiveMustBeAValidPath';
+
+export { enhance as entityApiSchemaAdvancedDataSetupEnhancer } from './model/EntityApiSchemaAdvancedData';
+export { enhance as equalityConstraintEnhancer } from './enhancer/EqualityConstraintEnhancer';
+export type { EqualityConstraint } from './model/EqualityConstraint';
+
+export function initialize(): MetaEdPlugin {
+  return {
+    enhancer: [entityApiSchemaAdvancedDataSetupEnhancer, equalityConstraintEnhancer],
+    validator: [mergeDirectiveMustBeAValidPath],
+    generator: [],
+    shortName: 'edfiApiSchemaAdvanced',
+  };
+}

--- a/packages/metaed-plugin-edfi-api-schema-advanced/src/model/EntityApiSchemaAdvancedData.ts
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/src/model/EntityApiSchemaAdvancedData.ts
@@ -1,0 +1,46 @@
+import { MetaEdEnvironment, EnhancerResult, getAllEntitiesOfType, ModelBase } from '@edfi/metaed-core';
+import type { EqualityConstraint } from './EqualityConstraint';
+
+export type EntityApiSchemaAdvancedData = {
+  /**
+   * A list of EqualityConstraints to be applied to an Ed-Fi API document. An EqualityConstraint
+   * is a source/target JsonPath pair.
+   */
+  equalityConstraints: EqualityConstraint[];
+};
+
+/**
+ * Initialize entity with ApiSchema data placeholder.
+ */
+export function addEntityApiSchemaAdvancedDataTo(entity: ModelBase) {
+  if (entity.data.edfiApiSchema == null) entity.data.edfiApiSchemaAdvanced = {};
+
+  Object.assign(entity.data.edfiApiSchemaAdvanced, {
+    equalityConstraints: [],
+  });
+}
+
+/**
+ * Initialize all properties with ApiSchemaAdvanced data placeholder.
+ */
+export function enhance(metaEd: MetaEdEnvironment): EnhancerResult {
+  getAllEntitiesOfType(
+    metaEd,
+    'domainEntity',
+    'association',
+    'domainEntitySubclass',
+    'associationSubclass',
+    'descriptor',
+    'common',
+    'choice',
+    'schoolYearEnumeration',
+  ).forEach((entity) => {
+    if (entity.data.edfiApiSchemaAdvanced == null) entity.data.edfiApiSchemaAdvanced = {};
+    addEntityApiSchemaAdvancedDataTo(entity);
+  });
+
+  return {
+    enhancerName: 'EntityApiSchemaDataSetupEnhancer',
+    success: true,
+  };
+}

--- a/packages/metaed-plugin-edfi-api-schema-advanced/src/model/EqualityConstraint.ts
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/src/model/EqualityConstraint.ts
@@ -1,4 +1,4 @@
-import { JsonPath } from './PathTypes';
+import { JsonPath } from '@edfi/metaed-plugin-edfi-api-schema';
 
 /**
  * A pair of JsonPaths, the value of which must be equal in an Ed-Fi API JSON document.

--- a/packages/metaed-plugin-edfi-api-schema-advanced/src/validator/MergeDirectiveMustBeAValidPath.ts
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/src/validator/MergeDirectiveMustBeAValidPath.ts
@@ -1,0 +1,58 @@
+import {
+  getAllEntitiesOfType,
+  MetaEdEnvironment,
+  TopLevelEntity,
+  isReferentialProperty,
+  ReferentialProperty,
+  MergeDirective,
+  EntityProperty,
+  ValidationFailure,
+} from '@edfi/metaed-core';
+import type { EntityApiSchemaData, PropertyPath } from '@edfi/metaed-plugin-edfi-api-schema';
+
+function mergeDirectivePathStringsToPath(segments: string[]): PropertyPath {
+  return segments.join('.') as PropertyPath;
+}
+export function validate(metaEd: MetaEdEnvironment): ValidationFailure[] {
+  const failures: ValidationFailure[] = [];
+
+  // entities with referential properties
+  getAllEntitiesOfType(metaEd, 'domainEntity', 'association', 'domainEntitySubclass', 'associationSubclass').forEach(
+    (entity) => {
+      // find referential properties on entity with merge directives
+      (entity as TopLevelEntity).properties.forEach((property: EntityProperty) => {
+        if (isReferentialProperty(property)) {
+          const referentialProperty: ReferentialProperty = property as ReferentialProperty;
+          referentialProperty.mergeDirectives.forEach((mergeDirective: MergeDirective) => {
+            // jsonPathsMapping has all valid paths for an entity
+            const { jsonPathsMapping } = entity.data.edfiApiSchema as EntityApiSchemaData;
+
+            const sourceMergePath: PropertyPath = mergeDirectivePathStringsToPath(mergeDirective.sourcePropertyPathStrings);
+            if (jsonPathsMapping[sourceMergePath] == null) {
+              failures.push({
+                validatorName: 'MergeDirectiveMustBeAValidPath',
+                category: 'error',
+                message: `Merge directive path ${sourceMergePath} is not a valid path on ${entity.metaEdName}`,
+                sourceMap: mergeDirective.sourceMap.sourcePropertyPathStrings,
+                fileMap: null,
+              });
+            }
+
+            const targetMergePath: PropertyPath = mergeDirectivePathStringsToPath(mergeDirective.targetPropertyPathStrings);
+            if (jsonPathsMapping[targetMergePath] == null) {
+              failures.push({
+                validatorName: 'MergeDirectiveMustBeAValidPath',
+                category: 'error',
+                message: `Merge directive path ${targetMergePath} is not a valid path on ${entity.metaEdName}`,
+                sourceMap: mergeDirective.sourceMap.targetPropertyPathStrings,
+                fileMap: null,
+              });
+            }
+          });
+        }
+      });
+    },
+  );
+
+  return failures;
+}

--- a/packages/metaed-plugin-edfi-api-schema-advanced/test/.eslintrc
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/test/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "env": {
+    "jest": true
+  },
+  "rules": {
+    "no-unused-expressions": "off",
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ]
+  }
+}

--- a/packages/metaed-plugin-edfi-api-schema-advanced/test/enhancer/EqualityConstraintEnhancer.test.ts
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/test/enhancer/EqualityConstraintEnhancer.test.ts
@@ -1,0 +1,722 @@
+import {
+  newMetaEdEnvironment,
+  MetaEdEnvironment,
+  DomainEntityBuilder,
+  MetaEdTextBuilder,
+  NamespaceBuilder,
+  AssociationBuilder,
+  ChoiceBuilder,
+  CommonBuilder,
+} from '@edfi/metaed-core';
+import {
+  associationReferenceEnhancer,
+  choiceReferenceEnhancer,
+  commonReferenceEnhancer,
+  domainEntityReferenceEnhancer,
+  mergeDirectiveEnhancer,
+} from '@edfi/metaed-plugin-edfi-unified';
+import {
+  entityPropertyApiSchemaDataSetupEnhancer,
+  entityApiSchemaDataSetupEnhancer,
+  referenceComponentEnhancer,
+  propertyCollectingEnhancer,
+  apiEntityMappingEnhancer,
+  apiPropertyMappingEnhancer,
+  jsonPathsMappingEnhancer,
+} from '@edfi/metaed-plugin-edfi-api-schema';
+
+import { enhance } from '../../src/enhancer/EqualityConstraintEnhancer';
+import { enhance as entityApiSchemaAdvancedDataSetupEnhancer } from '../../src/model/EntityApiSchemaAdvancedData';
+
+describe('when building domain entity with DomainEntity collection and single merge directive', () => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+  const namespace = 'EdFi';
+
+  beforeAll(() => {
+    MetaEdTextBuilder.build()
+      .withBeginNamespace('EdFi')
+      .withStartDomainEntity('GradingPeriod')
+      .withDocumentation('doc')
+      .withEnumerationIdentity('SchoolYear', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Session')
+      .withDocumentation('doc')
+      .withStringIdentity('SessionName', 'doc', '30')
+      .withEnumerationIdentity('SchoolYear', 'doc')
+      .withDomainEntityProperty('GradingPeriod', 'doc', false, true)
+      .withMergeDirective('GradingPeriod.SchoolYear', 'SchoolYear')
+      .withEndDomainEntity()
+      .withEndNamespace()
+
+      .sendToListener(new NamespaceBuilder(metaEd, []))
+      .sendToListener(new DomainEntityBuilder(metaEd, []));
+
+    domainEntityReferenceEnhancer(metaEd);
+    mergeDirectiveEnhancer(metaEd);
+    entityPropertyApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaAdvancedDataSetupEnhancer(metaEd);
+    referenceComponentEnhancer(metaEd);
+    apiPropertyMappingEnhancer(metaEd);
+    propertyCollectingEnhancer(metaEd);
+    apiEntityMappingEnhancer(metaEd);
+    jsonPathsMappingEnhancer(metaEd);
+    enhance(metaEd);
+  });
+
+  it('should create the correct equality constraints', () => {
+    const entity = metaEd.namespace.get(namespace)?.entity.domainEntity.get('Session');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolYear",
+          "targetJsonPath": "$.schoolYearTypeReference.schoolYear",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when building domain entity with single merge directive', () => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+  const namespace = 'EdFi';
+
+  beforeAll(() => {
+    MetaEdTextBuilder.build()
+      .withBeginNamespace('EdFi')
+      .withStartDomainEntity('School')
+      .withDocumentation('doc')
+      .withIntegerIdentity('SchoolId', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Session')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('CourseOffering')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Session', 'doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withMergeDirective('School', 'Session.School')
+      .withEndDomainEntity()
+      .withEndNamespace()
+
+      .sendToListener(new NamespaceBuilder(metaEd, []))
+      .sendToListener(new DomainEntityBuilder(metaEd, []));
+
+    domainEntityReferenceEnhancer(metaEd);
+    mergeDirectiveEnhancer(metaEd);
+    entityPropertyApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaAdvancedDataSetupEnhancer(metaEd);
+    referenceComponentEnhancer(metaEd);
+    apiPropertyMappingEnhancer(metaEd);
+    propertyCollectingEnhancer(metaEd);
+    apiEntityMappingEnhancer(metaEd);
+    jsonPathsMappingEnhancer(metaEd);
+    enhance(metaEd);
+  });
+
+  it('should create the correct equality constraints', () => {
+    const entity = metaEd.namespace.get(namespace)?.entity.domainEntity.get('CourseOffering');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.schoolReference.schoolId",
+          "targetJsonPath": "$.sessionReference.schoolId",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when building domain entity with DomainEntity collection and two merge directives', () => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+  const namespace = 'EdFi';
+
+  beforeAll(() => {
+    MetaEdTextBuilder.build()
+      .withBeginNamespace('EdFi')
+      .withStartDomainEntity('GradingPeriod')
+      .withDocumentation('doc')
+      .withEnumerationIdentity('SchoolYear', 'doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('School')
+      .withDocumentation('doc')
+      .withIntegerIdentity('SchoolId', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Session')
+      .withDocumentation('doc')
+      .withStringIdentity('SessionName', 'doc', '30')
+      .withEnumerationIdentity('SchoolYear', 'doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withDomainEntityProperty('GradingPeriod', 'doc', false, true)
+      .withMergeDirective('GradingPeriod.SchoolYear', 'SchoolYear')
+      .withMergeDirective('GradingPeriod.School', 'School')
+      .withEndDomainEntity()
+      .withEndNamespace()
+
+      .sendToListener(new NamespaceBuilder(metaEd, []))
+      .sendToListener(new DomainEntityBuilder(metaEd, []));
+
+    domainEntityReferenceEnhancer(metaEd);
+    mergeDirectiveEnhancer(metaEd);
+    entityPropertyApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaAdvancedDataSetupEnhancer(metaEd);
+    referenceComponentEnhancer(metaEd);
+    apiPropertyMappingEnhancer(metaEd);
+    propertyCollectingEnhancer(metaEd);
+    apiEntityMappingEnhancer(metaEd);
+    jsonPathsMappingEnhancer(metaEd);
+    enhance(metaEd);
+  });
+
+  it('should create the correct equality constraints', () => {
+    const entity = metaEd.namespace.get(namespace)?.entity.domainEntity.get('Session');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolYear",
+          "targetJsonPath": "$.schoolYearTypeReference.schoolYear",
+        },
+        Object {
+          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolId",
+          "targetJsonPath": "$.schoolReference.schoolId",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when building domain entity with DomainEntity collection and single merge directive with multiple levels on target reference', () => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+  const namespace = 'EdFi';
+
+  beforeAll(() => {
+    MetaEdTextBuilder.build()
+      .withBeginNamespace('EdFi')
+      .withStartDomainEntity('ClassPeriod')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('School')
+      .withDocumentation('doc')
+      .withIntegerIdentity('SchoolId', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Session')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('CourseOffering')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Session', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Section')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('CourseOffering', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('StudentSectionAttendanceEvent')
+      .withDocumentation('doc')
+      .withDomainEntityProperty('ClassPeriod', 'doc', false, true)
+      .withDomainEntityIdentity('Section', 'doc')
+      .withMergeDirective('ClassPeriod.School', 'Section.CourseOffering.Session.School')
+      .withEndDomainEntity()
+      .withEndNamespace()
+
+      .sendToListener(new NamespaceBuilder(metaEd, []))
+      .sendToListener(new DomainEntityBuilder(metaEd, []));
+
+    domainEntityReferenceEnhancer(metaEd);
+    mergeDirectiveEnhancer(metaEd);
+    entityPropertyApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaAdvancedDataSetupEnhancer(metaEd);
+    referenceComponentEnhancer(metaEd);
+    apiPropertyMappingEnhancer(metaEd);
+    propertyCollectingEnhancer(metaEd);
+    apiEntityMappingEnhancer(metaEd);
+    jsonPathsMappingEnhancer(metaEd);
+    enhance(metaEd);
+  });
+
+  it('should create the correct equality constraints', () => {
+    const entity = metaEd.namespace.get(namespace)?.entity.domainEntity.get('StudentSectionAttendanceEvent');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.classPeriods[*].classPeriodReference.schoolId",
+          "targetJsonPath": "$.sectionReference.schoolId",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when building domain entity with DomainEntity collection and single merge directive with multiple levels ending with simple type', () => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+  const namespace = 'EdFi';
+
+  beforeAll(() => {
+    MetaEdTextBuilder.build()
+      .withBeginNamespace('EdFi')
+      .withStartDomainEntity('ClassPeriod')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('School')
+      .withDocumentation('doc')
+      .withIntegerIdentity('SchoolId', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Session')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('CourseOffering')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Session', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Section')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('CourseOffering', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('StudentSectionAttendanceEvent')
+      .withDocumentation('doc')
+      .withDomainEntityProperty('ClassPeriod', 'doc', false, true)
+      .withDomainEntityIdentity('Section', 'doc')
+      .withMergeDirective('ClassPeriod.School.SchoolId', 'Section.CourseOffering.Session.School.SchoolId')
+      .withEndDomainEntity()
+      .withEndNamespace()
+
+      .sendToListener(new NamespaceBuilder(metaEd, []))
+      .sendToListener(new DomainEntityBuilder(metaEd, []));
+
+    domainEntityReferenceEnhancer(metaEd);
+    mergeDirectiveEnhancer(metaEd);
+    entityPropertyApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaAdvancedDataSetupEnhancer(metaEd);
+    referenceComponentEnhancer(metaEd);
+    apiPropertyMappingEnhancer(metaEd);
+    propertyCollectingEnhancer(metaEd);
+    apiEntityMappingEnhancer(metaEd);
+    jsonPathsMappingEnhancer(metaEd);
+    enhance(metaEd);
+  });
+
+  it('should create the correct equality constraints', () => {
+    const entity = metaEd.namespace.get(namespace)?.entity.domainEntity.get('StudentSectionAttendanceEvent');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.classPeriods[*].classPeriodReference.schoolId",
+          "targetJsonPath": "$.sectionReference.schoolId",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when two domain entities with all four possible simple identities are merged on a reference', () => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+  const namespaceName = 'EdFi';
+  const domainEntityWithMerges = 'DomainEntityWithMerges';
+  const domainEntityBeingMergedFrom = 'DomainEntityBeingMergedFrom';
+  const domainEntityBeingMergedTo = 'DomainEntityBeingMergedTo';
+  const booleanProperty = 'BooleanProperty';
+  const schoolYear = 'SchoolYear';
+  const integerProperty = 'IntegerProperty';
+  const stringProperty = 'StringProperty';
+
+  beforeAll(() => {
+    MetaEdTextBuilder.build()
+      .withBeginNamespace(namespaceName)
+      .withStartDomainEntity(domainEntityBeingMergedTo)
+      .withDocumentation('doc')
+      .withBooleanIdentity(booleanProperty, 'doc')
+      .withEnumerationIdentity(schoolYear, 'doc')
+      .withIntegerIdentity(integerProperty, 'doc')
+      .withStringIdentity(stringProperty, 'doc', '10')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity(domainEntityBeingMergedFrom)
+      .withDocumentation('doc')
+      .withBooleanIdentity(booleanProperty, 'doc')
+      .withEnumerationIdentity(schoolYear, 'doc')
+      .withIntegerIdentity(integerProperty, 'doc')
+      .withStringIdentity(stringProperty, 'doc', '10')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity(domainEntityWithMerges)
+      .withDocumentation('doc')
+
+      .withDomainEntityIdentity(domainEntityBeingMergedFrom, 'doc')
+      .withMergeDirective(
+        `${domainEntityBeingMergedFrom}.${booleanProperty}`,
+        `${domainEntityBeingMergedTo}.${booleanProperty}`,
+      )
+      .withMergeDirective(`${domainEntityBeingMergedFrom}.${schoolYear}`, `${domainEntityBeingMergedTo}.${schoolYear}`)
+      .withMergeDirective(
+        `${domainEntityBeingMergedFrom}.${integerProperty}`,
+        `${domainEntityBeingMergedTo}.${integerProperty}`,
+      )
+      .withMergeDirective(
+        `${domainEntityBeingMergedFrom}.${stringProperty}`,
+        `${domainEntityBeingMergedTo}.${stringProperty}`,
+      )
+      .withDomainEntityIdentity(domainEntityBeingMergedTo, 'doc')
+      .withEndDomainEntity()
+
+      .withEndNamespace()
+      .sendToListener(new NamespaceBuilder(metaEd, []))
+      .sendToListener(new DomainEntityBuilder(metaEd, []));
+
+    domainEntityReferenceEnhancer(metaEd);
+    mergeDirectiveEnhancer(metaEd);
+    entityPropertyApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaAdvancedDataSetupEnhancer(metaEd);
+    referenceComponentEnhancer(metaEd);
+    apiPropertyMappingEnhancer(metaEd);
+    propertyCollectingEnhancer(metaEd);
+    apiEntityMappingEnhancer(metaEd);
+    jsonPathsMappingEnhancer(metaEd);
+    enhance(metaEd);
+  });
+
+  it('should create the correct equality constraints', () => {
+    const entity = metaEd.namespace.get(namespaceName)?.entity.domainEntity.get(domainEntityWithMerges);
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.domainEntityBeingMergedFromReference.booleanProperty",
+          "targetJsonPath": "$.domainEntityBeingMergedToReference.booleanProperty",
+        },
+        Object {
+          "sourceJsonPath": "$.domainEntityBeingMergedFromReference.schoolYear",
+          "targetJsonPath": "$.domainEntityBeingMergedToReference.schoolYear",
+        },
+        Object {
+          "sourceJsonPath": "$.domainEntityBeingMergedFromReference.integerProperty",
+          "targetJsonPath": "$.domainEntityBeingMergedToReference.integerProperty",
+        },
+        Object {
+          "sourceJsonPath": "$.domainEntityBeingMergedFromReference.stringProperty",
+          "targetJsonPath": "$.domainEntityBeingMergedToReference.stringProperty",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when merging on both a reference and a simple identity down multiple levels on both references', () => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+  const namespaceName = 'EdFi';
+
+  beforeAll(() => {
+    MetaEdTextBuilder.build()
+      .withBeginNamespace(namespaceName)
+      .withStartDomainEntity('SectionAttendanceTakenEvent')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Section', 'doc')
+      .withDomainEntityIdentity('CalendarDate', 'doc')
+      .withMergeDirective('CalendarDate.Calendar.School', 'Section.CourseOffering.Session.School')
+      .withMergeDirective('CalendarDate.Calendar.SchoolYear', 'Section.CourseOffering.Session.SchoolYear')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Section')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('CourseOffering', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('CourseOffering')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Session', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Session')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withEnumerationIdentity('SchoolYear', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('School')
+      .withDocumentation('doc')
+      .withIntegerIdentity('SchoolId', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('CalendarDate')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Calendar', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Calendar')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withEnumerationIdentity('SchoolYear', 'doc')
+      .withEndDomainEntity()
+
+      .withEndNamespace()
+      .sendToListener(new NamespaceBuilder(metaEd, []))
+      .sendToListener(new DomainEntityBuilder(metaEd, []));
+
+    domainEntityReferenceEnhancer(metaEd);
+    mergeDirectiveEnhancer(metaEd);
+    entityPropertyApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaAdvancedDataSetupEnhancer(metaEd);
+    referenceComponentEnhancer(metaEd);
+    apiPropertyMappingEnhancer(metaEd);
+    propertyCollectingEnhancer(metaEd);
+    apiEntityMappingEnhancer(metaEd);
+    jsonPathsMappingEnhancer(metaEd);
+    enhance(metaEd);
+  });
+
+  it('should create the correct equality constraints', () => {
+    const entity = metaEd.namespace.get(namespaceName)?.entity.domainEntity.get('SectionAttendanceTakenEvent');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.calendarDateReference.schoolId",
+          "targetJsonPath": "$.sectionReference.schoolId",
+        },
+        Object {
+          "sourceJsonPath": "$.calendarDateReference.schoolYear",
+          "targetJsonPath": "$.sectionReference.schoolYear",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when merging on a reference with multiple levels of domain entities below it', () => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+  const namespaceName = 'EdFi';
+
+  beforeAll(() => {
+    MetaEdTextBuilder.build()
+      .withBeginNamespace(namespaceName)
+      .withStartDomainEntity('DomainEntityName')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Section', 'doc')
+      .withDomainEntityIdentity('CourseOffering', 'doc')
+      .withMergeDirective('CourseOffering', 'Section.CourseOffering')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Section')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('CourseOffering', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('CourseOffering')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Session', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Session')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('School', 'doc')
+      .withEnumerationIdentity('SchoolYear', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('School')
+      .withDocumentation('doc')
+      .withIntegerIdentity('SchoolId', 'doc')
+      .withDomainEntityIdentity('CalendarDate', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('CalendarDate')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Calendar', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Calendar')
+      .withDocumentation('doc')
+      .withIntegerIdentity('Days', 'doc')
+      .withEnumerationIdentity('SchoolYear', 'doc')
+      .withEndDomainEntity()
+
+      .withEndNamespace()
+      .sendToListener(new NamespaceBuilder(metaEd, []))
+      .sendToListener(new DomainEntityBuilder(metaEd, []));
+
+    domainEntityReferenceEnhancer(metaEd);
+    mergeDirectiveEnhancer(metaEd);
+    entityPropertyApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaAdvancedDataSetupEnhancer(metaEd);
+    referenceComponentEnhancer(metaEd);
+    apiPropertyMappingEnhancer(metaEd);
+    propertyCollectingEnhancer(metaEd);
+    apiEntityMappingEnhancer(metaEd);
+    jsonPathsMappingEnhancer(metaEd);
+    enhance(metaEd);
+  });
+
+  it('should create the correct equality constraints', () => {
+    const entity = metaEd.namespace.get(namespaceName)?.entity.domainEntity.get('DomainEntityName');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.courseOfferingReference.days",
+          "targetJsonPath": "$.sectionReference.days",
+        },
+        Object {
+          "sourceJsonPath": "$.courseOfferingReference.schoolId",
+          "targetJsonPath": "$.sectionReference.schoolId",
+        },
+        Object {
+          "sourceJsonPath": "$.courseOfferingReference.schoolYear",
+          "targetJsonPath": "$.sectionReference.schoolYear",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when merging on a reference through a choice', () => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+  const namespaceName = 'EdFi';
+
+  beforeAll(() => {
+    MetaEdTextBuilder.build()
+      .withBeginNamespace(namespaceName)
+      .withStartDomainEntity('StudentCompetencyObjective')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Student', 'doc')
+      .withChoiceProperty('StudentCompetencyObjectiveChoice', 'doc', false, false)
+      .withMergeDirective('StudentCompetencyObjectiveChoice.StudentSectionAssociation.Student', 'Student')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Student')
+      .withDocumentation('doc')
+      .withIntegerIdentity('StudentId', 'doc')
+      .withEndDomainEntity()
+
+      .withStartChoice('StudentCompetencyObjectiveChoice')
+      .withDocumentation('doc')
+      .withAssociationProperty('StudentSectionAssociation', 'doc', false, true)
+      .withEndChoice()
+
+      .withStartAssociation('StudentSectionAssociation')
+      .withDocumentation('doc')
+      .withAssociationDomainEntityProperty('Student', 'doc')
+      .withAssociationDomainEntityProperty('Section', 'doc')
+      .withEndAssociation()
+
+      .withStartDomainEntity('Section')
+      .withDocumentation('doc')
+      .withIntegerIdentity('SectionId', 'doc')
+      .withEndDomainEntity()
+
+      .withEndNamespace()
+      .sendToListener(new NamespaceBuilder(metaEd, []))
+      .sendToListener(new AssociationBuilder(metaEd, []))
+      .sendToListener(new ChoiceBuilder(metaEd, []))
+      .sendToListener(new DomainEntityBuilder(metaEd, []));
+
+    domainEntityReferenceEnhancer(metaEd);
+    associationReferenceEnhancer(metaEd);
+    choiceReferenceEnhancer(metaEd);
+    mergeDirectiveEnhancer(metaEd);
+    entityPropertyApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaAdvancedDataSetupEnhancer(metaEd);
+    referenceComponentEnhancer(metaEd);
+    apiPropertyMappingEnhancer(metaEd);
+    propertyCollectingEnhancer(metaEd);
+    apiEntityMappingEnhancer(metaEd);
+    jsonPathsMappingEnhancer(metaEd);
+    enhance(metaEd);
+  });
+
+  it('should create the correct equality constraints', () => {
+    const entity = metaEd.namespace.get(namespaceName)?.entity.domainEntity.get('StudentCompetencyObjective');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.studentSectionAssociations[*].studentSectionAssociationReference.studentId",
+          "targetJsonPath": "$.studentReference.studentId",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when merging on a reference through a common collection', () => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+  const namespaceName = 'EdFi';
+
+  beforeAll(() => {
+    MetaEdTextBuilder.build()
+      .withBeginNamespace(namespaceName)
+
+      .withStartDomainEntity('StudentAssessment')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Assessment', 'doc')
+      .withCommonProperty('StudentAssessmentItem', 'doc', false, true)
+      .withMergeDirective('StudentAssessmentItem.AssessmentItem.Assessment', 'Assessment')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('Assessment')
+      .withDocumentation('doc')
+      .withIntegerIdentity('AssessmentId', 'doc')
+      .withEndDomainEntity()
+
+      .withStartDomainEntity('AssessmentItem')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('Assessment', 'doc')
+      .withEndDomainEntity()
+
+      .withStartCommon('StudentAssessmentItem')
+      .withDocumentation('doc')
+      .withDomainEntityIdentity('AssessmentItem', 'doc')
+      .withEndCommon()
+
+      .withEndNamespace()
+      .sendToListener(new NamespaceBuilder(metaEd, []))
+      .sendToListener(new CommonBuilder(metaEd, []))
+      .sendToListener(new DomainEntityBuilder(metaEd, []));
+
+    domainEntityReferenceEnhancer(metaEd);
+    commonReferenceEnhancer(metaEd);
+    mergeDirectiveEnhancer(metaEd);
+    entityPropertyApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaDataSetupEnhancer(metaEd);
+    entityApiSchemaAdvancedDataSetupEnhancer(metaEd);
+    referenceComponentEnhancer(metaEd);
+    apiPropertyMappingEnhancer(metaEd);
+    propertyCollectingEnhancer(metaEd);
+    apiEntityMappingEnhancer(metaEd);
+    jsonPathsMappingEnhancer(metaEd);
+    enhance(metaEd);
+  });
+
+  it('should create the correct equality constraints', () => {
+    const entity = metaEd.namespace.get(namespaceName)?.entity.domainEntity.get('StudentAssessment');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.items[*].assessmentItemReference.assessmentId",
+          "targetJsonPath": "$.assessmentReference.assessmentId",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/metaed-plugin-edfi-api-schema-advanced/test/integration/DataStandardIntegration.test.ts
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/test/integration/DataStandardIntegration.test.ts
@@ -1,0 +1,323 @@
+import { State, MetaEdEnvironment, newMetaEdEnvironment } from '@edfi/metaed-core';
+import {
+  buildMetaEd,
+  buildParseTree,
+  loadFileIndex,
+  loadFiles,
+  initializeNamespaces,
+  newMetaEdConfiguration,
+  newState,
+  runEnhancers,
+  setupPlugins,
+  walkBuilders,
+} from '@edfi/metaed-core';
+import { metaEdPlugins } from './PluginHelper';
+
+jest.setTimeout(40000);
+
+describe('when generating api schema targeting tech version 5.3 with data standard 3.3b', (): void => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+
+  beforeAll(async () => {
+    const metaEdConfiguration = {
+      ...newMetaEdConfiguration(),
+      artifactDirectory: './MetaEdOutput/',
+      defaultPluginTechVersion: '5.3.0',
+      projectPaths: ['./node_modules/@edfi/ed-fi-model-3.3b/'],
+      projects: [
+        {
+          projectName: 'Ed-Fi',
+          namespaceName: 'EdFi',
+          projectExtension: '',
+          projectVersion: '3.3.1-b',
+          description: 'A description',
+        },
+      ],
+    };
+
+    const state: State = {
+      ...newState(),
+      metaEd,
+      metaEdConfiguration,
+      metaEdPlugins: metaEdPlugins(),
+    };
+    state.metaEd.dataStandardVersion = '3.3.1-b';
+
+    setupPlugins(state);
+    loadFiles(state);
+    loadFileIndex(state);
+    buildParseTree(buildMetaEd, state);
+    await walkBuilders(state);
+    initializeNamespaces(state);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const metaEdPlugin of state.metaEdPlugins) {
+      await runEnhancers(metaEdPlugin, state);
+    }
+  });
+
+  it('should create the correct equality constraints for StudentAssessment', () => {
+    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentAssessment');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.items[*].assessmentItemReference.assessmentIdentifier",
+          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
+        },
+        Object {
+          "sourceJsonPath": "$.items[*].assessmentItemReference.namespace",
+          "targetJsonPath": "$.assessmentReference.namespace",
+        },
+        Object {
+          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.assessmentIdentifier",
+          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
+        },
+        Object {
+          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.namespace",
+          "targetJsonPath": "$.assessmentReference.namespace",
+        },
+      ]
+    `);
+  });
+
+  it('should create the correct equality constraints for Session', () => {
+    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('Session');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolYear",
+          "targetJsonPath": "$.schoolYearTypeReference.schoolYear",
+        },
+        Object {
+          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolId",
+          "targetJsonPath": "$.schoolReference.schoolId",
+        },
+      ]
+    `);
+  });
+
+  it('should create the correct equality constraints for StudentCompetencyObjective', () => {
+    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentCompetencyObjective');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
+          "targetJsonPath": "$.studentReference.studentUniqueId",
+        },
+        Object {
+          "sourceJsonPath": "$.generalStudentProgramAssociations[*].generalStudentProgramAssociationReference.studentUniqueId",
+          "targetJsonPath": "$.studentReference.studentUniqueId",
+        },
+      ]
+    `);
+  });
+
+  it('should create the correct equality constraints for StudentLearningObjective', () => {
+    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentLearningObjective');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
+          "targetJsonPath": "$.studentReference.studentUniqueId",
+        },
+        Object {
+          "sourceJsonPath": "$.generalStudentProgramAssociations[*].generalStudentProgramAssociationReference.studentUniqueId",
+          "targetJsonPath": "$.studentReference.studentUniqueId",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when generating api schema targeting tech version 6.1 with data standard 4.0', (): void => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+
+  beforeAll(async () => {
+    const metaEdConfiguration = {
+      ...newMetaEdConfiguration(),
+      artifactDirectory: './MetaEdOutput/',
+      defaultPluginTechVersion: '6.1.0',
+      projectPaths: ['./node_modules/@edfi/ed-fi-model-4.0/'],
+      projects: [
+        {
+          projectName: 'Ed-Fi',
+          namespaceName: 'EdFi',
+          projectExtension: '',
+          projectVersion: '4.0.0',
+          description: '',
+        },
+      ],
+    };
+
+    const state: State = {
+      ...newState(),
+      metaEd,
+      metaEdConfiguration,
+      metaEdPlugins: metaEdPlugins(),
+    };
+    state.metaEd.dataStandardVersion = '4.0.0';
+
+    setupPlugins(state);
+    loadFiles(state);
+    loadFileIndex(state);
+    buildParseTree(buildMetaEd, state);
+    await walkBuilders(state);
+    initializeNamespaces(state);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const metaEdPlugin of state.metaEdPlugins) {
+      await runEnhancers(metaEdPlugin, state);
+    }
+  });
+
+  it('should create the correct equality constraints for StudentAssessment', () => {
+    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentAssessment');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.items[*].assessmentItemReference.assessmentIdentifier",
+          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
+        },
+        Object {
+          "sourceJsonPath": "$.items[*].assessmentItemReference.namespace",
+          "targetJsonPath": "$.assessmentReference.namespace",
+        },
+        Object {
+          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.assessmentIdentifier",
+          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
+        },
+        Object {
+          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.namespace",
+          "targetJsonPath": "$.assessmentReference.namespace",
+        },
+      ]
+    `);
+  });
+
+  it('should create the correct equality constraints for Session', () => {
+    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('Session');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolYear",
+          "targetJsonPath": "$.schoolYearTypeReference.schoolYear",
+        },
+        Object {
+          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolId",
+          "targetJsonPath": "$.schoolReference.schoolId",
+        },
+      ]
+    `);
+  });
+
+  it('should create the correct equality constraints for StudentCompetencyObjective', () => {
+    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentCompetencyObjective');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
+          "targetJsonPath": "$.studentReference.studentUniqueId",
+        },
+        Object {
+          "sourceJsonPath": "$.generalStudentProgramAssociations[*].generalStudentProgramAssociationReference.studentUniqueId",
+          "targetJsonPath": "$.studentReference.studentUniqueId",
+        },
+      ]
+    `);
+  });
+});
+
+describe('when generating api schema targeting tech version 7.0 with data standard 5.0-pre.1', (): void => {
+  const metaEd: MetaEdEnvironment = newMetaEdEnvironment();
+
+  beforeAll(async () => {
+    const metaEdConfiguration = {
+      ...newMetaEdConfiguration(),
+      artifactDirectory: './MetaEdOutput/',
+      defaultPluginTechVersion: '7.0.0',
+      projectPaths: ['./node_modules/@edfi/ed-fi-model-5.0-pre.1/'],
+      projects: [
+        {
+          projectName: 'Ed-Fi',
+          namespaceName: 'EdFi',
+          projectExtension: '',
+          projectVersion: '4.0.0',
+          description: '',
+        },
+      ],
+    };
+
+    const state: State = {
+      ...newState(),
+      metaEd,
+      metaEdConfiguration,
+      metaEdPlugins: metaEdPlugins(),
+    };
+    state.metaEd.dataStandardVersion = '4.0.0';
+
+    setupPlugins(state);
+    loadFiles(state);
+    loadFileIndex(state);
+    buildParseTree(buildMetaEd, state);
+    await walkBuilders(state);
+    initializeNamespaces(state);
+    // eslint-disable-next-line no-restricted-syntax
+    for (const metaEdPlugin of state.metaEdPlugins) {
+      await runEnhancers(metaEdPlugin, state);
+    }
+  });
+
+  it('should create the correct equality constraints for StudentAssessment', () => {
+    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentAssessment');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.items[*].assessmentItemReference.assessmentIdentifier",
+          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
+        },
+        Object {
+          "sourceJsonPath": "$.items[*].assessmentItemReference.namespace",
+          "targetJsonPath": "$.assessmentReference.namespace",
+        },
+        Object {
+          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.assessmentIdentifier",
+          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
+        },
+        Object {
+          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.namespace",
+          "targetJsonPath": "$.assessmentReference.namespace",
+        },
+      ]
+    `);
+  });
+
+  it('should create the correct equality constraints for Session', () => {
+    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('Session');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolYear",
+          "targetJsonPath": "$.schoolYearTypeReference.schoolYear",
+        },
+        Object {
+          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolId",
+          "targetJsonPath": "$.schoolReference.schoolId",
+        },
+      ]
+    `);
+  });
+
+  it('should create the correct equality constraints for StudentCompetencyObjective', () => {
+    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentCompetencyObjective');
+    expect(entity?.data.edfiApiSchemaAdvanced.equalityConstraints).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "sourceJsonPath": "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
+          "targetJsonPath": "$.studentReference.studentUniqueId",
+        },
+        Object {
+          "sourceJsonPath": "$.generalStudentProgramAssociations[*].generalStudentProgramAssociationReference.studentUniqueId",
+          "targetJsonPath": "$.studentReference.studentUniqueId",
+        },
+      ]
+    `);
+  });
+});

--- a/packages/metaed-plugin-edfi-api-schema-advanced/test/integration/PluginHelper.ts
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/test/integration/PluginHelper.ts
@@ -1,0 +1,9 @@
+import type { MetaEdPlugin } from '@edfi/metaed-core';
+
+import { initialize as edfiUnified } from '@edfi/metaed-plugin-edfi-unified';
+import { initialize as edfiApiSchema } from '@edfi/metaed-plugin-edfi-api-schema';
+import { initialize } from '../../src/index';
+
+export function metaEdPlugins(): MetaEdPlugin[] {
+  return [edfiUnified(), edfiApiSchema(), initialize()];
+}

--- a/packages/metaed-plugin-edfi-api-schema-advanced/tsconfig.json
+++ b/packages/metaed-plugin-edfi-api-schema-advanced/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist"
+  },
+  "include": [
+    "./src"
+  ]
+}

--- a/packages/metaed-plugin-edfi-api-schema/src/enhancer/EnhancerList.ts
+++ b/packages/metaed-plugin-edfi-api-schema/src/enhancer/EnhancerList.ts
@@ -11,7 +11,6 @@ import { enhance as subclassPropertyCollectingEnhancer } from './SubclassPropert
 import { enhance as jsonSchemaEnhancerForInsert } from './JsonSchemaEnhancerForInsert';
 import { enhance as jsonSchemaEnhancerForUpdate } from './JsonSchemaEnhancerForUpdate';
 import { enhance as jsonPathsMappingEnhancer } from './JsonPathsMappingEnhancer';
-import { enhance as equalityConstraintEnhancer } from './EqualityConstraintEnhancer';
 
 export function enhancerList(): Enhancer[] {
   return [
@@ -27,6 +26,5 @@ export function enhancerList(): Enhancer[] {
     jsonSchemaEnhancerForInsert,
     jsonSchemaEnhancerForUpdate,
     jsonPathsMappingEnhancer,
-    equalityConstraintEnhancer,
   ];
 }

--- a/packages/metaed-plugin-edfi-api-schema/src/index.ts
+++ b/packages/metaed-plugin-edfi-api-schema/src/index.ts
@@ -5,7 +5,6 @@ export { enhance as entityApiSchemaDataSetupEnhancer } from './model/EntityApiSc
 export { enhance as entityPropertyApiSchemaDataSetupEnhancer } from './model/EntityPropertyApiSchemaData';
 export { enhance as apiEntityMappingEnhancer } from './enhancer/ApiEntityMappingEnhancer';
 export { enhance as apiPropertyMappingEnhancer } from './enhancer/ApiPropertyMappingEnhancer';
-export { enhance as equalityConstraintEnhancer } from './enhancer/EqualityConstraintEnhancer';
 export { enhance as jsonPathsMappingEnhancer } from './enhancer/JsonPathsMappingEnhancer';
 export { enhance as jsonSchemaEnhancerForInsert } from './enhancer/JsonSchemaEnhancerForInsert';
 export { enhance as jsonSchemaEnhancerForUpdate } from './enhancer/JsonSchemaEnhancerForUpdate';
@@ -23,7 +22,7 @@ export { isReferenceElement } from './model/ReferenceComponent';
 export type { ReferenceComponent, ReferenceGroup } from './model/ReferenceComponent';
 export { topLevelApiNameOnEntity, pluralize, uncapitalize } from './Utility';
 export type { ApiPropertyMapping } from './model/ApiPropertyMapping';
-export type { EqualityConstraint } from './model/EqualityConstraint';
+export type { JsonPath, PropertyPath } from './model/PathTypes';
 
 export function initialize(): MetaEdPlugin {
   return {

--- a/packages/metaed-plugin-edfi-api-schema/src/model/EntityApiSchemaData.ts
+++ b/packages/metaed-plugin-edfi-api-schema/src/model/EntityApiSchemaData.ts
@@ -2,7 +2,6 @@ import { MetaEdEnvironment, EnhancerResult, getAllEntitiesOfType, ModelBase } fr
 import { ApiEntityMapping, NoApiEntityMapping } from './ApiEntityMapping';
 import type { CollectedProperty } from './CollectedProperty';
 import { SchemaRoot, NoSchemaRoot } from './JsonSchema';
-import type { EqualityConstraint } from './EqualityConstraint';
 import type { JsonPathsMapping } from './JsonPathsMapping';
 
 export type EntityApiSchemaData = {
@@ -43,12 +42,6 @@ export type EntityApiSchemaData = {
    * The JsonPaths array is always is sorted order.
    */
   jsonPathsMapping: JsonPathsMapping;
-
-  /**
-   * A list of EqualityConstraints to be applied to an Ed-Fi API document. An EqualityConstraint
-   * is a source/target JsonPath pair.
-   */
-  equalityConstraints: EqualityConstraint[];
 };
 
 /**
@@ -62,7 +55,6 @@ export function addEntityApiSchemaDataTo(entity: ModelBase) {
     jsonSchemaForInsert: NoSchemaRoot,
     collectedApiProperties: [],
     jsonPathsMapping: {},
-    equalityConstraints: [],
   });
 }
 

--- a/packages/metaed-plugin-edfi-api-schema/test/integration/DataStandardIntegration.test.ts
+++ b/packages/metaed-plugin-edfi-api-schema/test/integration/DataStandardIntegration.test.ts
@@ -211,30 +211,6 @@ describe('when generating api schema targeting tech version 5.3 with data standa
     `);
   });
 
-  it('should create the correct equality constraints for StudentAssessment', () => {
-    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentAssessment');
-    expect(entity?.data.edfiApiSchema.equalityConstraints).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "sourceJsonPath": "$.items[*].assessmentItemReference.assessmentIdentifier",
-          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
-        },
-        Object {
-          "sourceJsonPath": "$.items[*].assessmentItemReference.namespace",
-          "targetJsonPath": "$.assessmentReference.namespace",
-        },
-        Object {
-          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.assessmentIdentifier",
-          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
-        },
-        Object {
-          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.namespace",
-          "targetJsonPath": "$.assessmentReference.namespace",
-        },
-      ]
-    `);
-  });
-
   it('should create the correct JSON path mappings for Session', () => {
     const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('Session');
     expect(entity?.data.edfiApiSchema.jsonPathsMapping).toMatchInlineSnapshot(`
@@ -298,22 +274,6 @@ describe('when generating api schema targeting tech version 5.3 with data standa
           "$.totalInstructionalDays",
         ],
       }
-    `);
-  });
-
-  it('should create the correct equality constraints for Session', () => {
-    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('Session');
-    expect(entity?.data.edfiApiSchema.equalityConstraints).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolYear",
-          "targetJsonPath": "$.schoolYearTypeReference.schoolYear",
-        },
-        Object {
-          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolId",
-          "targetJsonPath": "$.schoolReference.schoolId",
-        },
-      ]
     `);
   });
 
@@ -474,21 +434,6 @@ describe('when generating api schema targeting tech version 5.3 with data standa
     `);
   });
 
-  it('should create the correct equality constraints for StudentCompetencyObjective', () => {
-    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentCompetencyObjective');
-    expect(entity?.data.edfiApiSchema.equalityConstraints).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "sourceJsonPath": "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
-          "targetJsonPath": "$.studentReference.studentUniqueId",
-        },
-        Object {
-          "sourceJsonPath": "$.generalStudentProgramAssociations[*].generalStudentProgramAssociationReference.studentUniqueId",
-          "targetJsonPath": "$.studentReference.studentUniqueId",
-        },
-      ]
-    `);
-  });
   it('should create the correct JSON path mappings for StudentLearningObjective', () => {
     const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentLearningObjective');
     expect(entity?.data.edfiApiSchema.jsonPathsMapping).toMatchInlineSnapshot(`
@@ -636,22 +581,6 @@ describe('when generating api schema targeting tech version 5.3 with data standa
           "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
         ],
       }
-    `);
-  });
-
-  it('should create the correct equality constraints for StudentLearningObjective', () => {
-    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentLearningObjective');
-    expect(entity?.data.edfiApiSchema.equalityConstraints).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "sourceJsonPath": "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
-          "targetJsonPath": "$.studentReference.studentUniqueId",
-        },
-        Object {
-          "sourceJsonPath": "$.generalStudentProgramAssociations[*].generalStudentProgramAssociationReference.studentUniqueId",
-          "targetJsonPath": "$.studentReference.studentUniqueId",
-        },
-      ]
     `);
   });
 });
@@ -885,30 +814,6 @@ describe('when generating api schema targeting tech version 6.1 with data standa
     `);
   });
 
-  it('should create the correct equality constraints for StudentAssessment', () => {
-    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentAssessment');
-    expect(entity?.data.edfiApiSchema.equalityConstraints).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "sourceJsonPath": "$.items[*].assessmentItemReference.assessmentIdentifier",
-          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
-        },
-        Object {
-          "sourceJsonPath": "$.items[*].assessmentItemReference.namespace",
-          "targetJsonPath": "$.assessmentReference.namespace",
-        },
-        Object {
-          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.assessmentIdentifier",
-          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
-        },
-        Object {
-          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.namespace",
-          "targetJsonPath": "$.assessmentReference.namespace",
-        },
-      ]
-    `);
-  });
-
   it('should create the correct JSON path mappings for Session', () => {
     const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('Session');
     expect(entity?.data.edfiApiSchema.jsonPathsMapping).toMatchInlineSnapshot(`
@@ -972,22 +877,6 @@ describe('when generating api schema targeting tech version 6.1 with data standa
           "$.totalInstructionalDays",
         ],
       }
-    `);
-  });
-
-  it('should create the correct equality constraints for Session', () => {
-    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('Session');
-    expect(entity?.data.edfiApiSchema.equalityConstraints).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolYear",
-          "targetJsonPath": "$.schoolYearTypeReference.schoolYear",
-        },
-        Object {
-          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolId",
-          "targetJsonPath": "$.schoolReference.schoolId",
-        },
-      ]
     `);
   });
 
@@ -1145,22 +1034,6 @@ describe('when generating api schema targeting tech version 6.1 with data standa
           "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
         ],
       }
-    `);
-  });
-
-  it('should create the correct equality constraints for StudentCompetencyObjective', () => {
-    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentCompetencyObjective');
-    expect(entity?.data.edfiApiSchema.equalityConstraints).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "sourceJsonPath": "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
-          "targetJsonPath": "$.studentReference.studentUniqueId",
-        },
-        Object {
-          "sourceJsonPath": "$.generalStudentProgramAssociations[*].generalStudentProgramAssociationReference.studentUniqueId",
-          "targetJsonPath": "$.studentReference.studentUniqueId",
-        },
-      ]
     `);
   });
 });
@@ -1394,30 +1267,6 @@ describe('when generating api schema targeting tech version 7.0 with data standa
     `);
   });
 
-  it('should create the correct equality constraints for StudentAssessment', () => {
-    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentAssessment');
-    expect(entity?.data.edfiApiSchema.equalityConstraints).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "sourceJsonPath": "$.items[*].assessmentItemReference.assessmentIdentifier",
-          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
-        },
-        Object {
-          "sourceJsonPath": "$.items[*].assessmentItemReference.namespace",
-          "targetJsonPath": "$.assessmentReference.namespace",
-        },
-        Object {
-          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.assessmentIdentifier",
-          "targetJsonPath": "$.assessmentReference.assessmentIdentifier",
-        },
-        Object {
-          "sourceJsonPath": "$.studentObjectiveAssessments[*].objectiveAssessmentReference.namespace",
-          "targetJsonPath": "$.assessmentReference.namespace",
-        },
-      ]
-    `);
-  });
-
   it('should create the correct JSON path mappings for Session', () => {
     const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('Session');
     expect(entity?.data.edfiApiSchema.jsonPathsMapping).toMatchInlineSnapshot(`
@@ -1481,22 +1330,6 @@ describe('when generating api schema targeting tech version 7.0 with data standa
           "$.totalInstructionalDays",
         ],
       }
-    `);
-  });
-
-  it('should create the correct equality constraints for Session', () => {
-    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('Session');
-    expect(entity?.data.edfiApiSchema.equalityConstraints).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolYear",
-          "targetJsonPath": "$.schoolYearTypeReference.schoolYear",
-        },
-        Object {
-          "sourceJsonPath": "$.gradingPeriods[*].gradingPeriodReference.schoolId",
-          "targetJsonPath": "$.schoolReference.schoolId",
-        },
-      ]
     `);
   });
 
@@ -1654,22 +1487,6 @@ describe('when generating api schema targeting tech version 7.0 with data standa
           "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
         ],
       }
-    `);
-  });
-
-  it('should create the correct equality constraints for StudentCompetencyObjective', () => {
-    const entity = metaEd.namespace.get('EdFi')?.entity.domainEntity.get('StudentCompetencyObjective');
-    expect(entity?.data.edfiApiSchema.equalityConstraints).toMatchInlineSnapshot(`
-      Array [
-        Object {
-          "sourceJsonPath": "$.studentSectionAssociations[*].studentSectionAssociationReference.studentUniqueId",
-          "targetJsonPath": "$.studentReference.studentUniqueId",
-        },
-        Object {
-          "sourceJsonPath": "$.generalStudentProgramAssociations[*].generalStudentProgramAssociationReference.studentUniqueId",
-          "targetJsonPath": "$.studentReference.studentUniqueId",
-        },
-      ]
     `);
   });
 });


### PR DESCRIPTION
Split off edfi-api-schema-advanced plugin from edfi-api-schema plugin, which allows the new validator to run before an enhancer that it is protecting.

This will require a small change to Meadowlark to reference the EqualityConstraint from a different location in the MetaEd model.

Need to wait to merge until MetaEd is using new DSes that have removed the invalid merges.