### PR TITLE
[METAED-1508] Block ApiSchema from ODS/API deploy processing

### DIFF
--- a/packages/metaed-odsapi-deploy/src/task/DeployConstants.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployConstants.ts
@@ -1,0 +1,1 @@
+export const directoryExcludeList = ['ApiSchema', 'Documentation', 'EdFi'];

--- a/packages/metaed-odsapi-deploy/src/task/DeployExtensionV3.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployExtensionV3.ts
@@ -3,6 +3,7 @@ import { Logger, MetaEdConfiguration, SemVer, versionSatisfies } from '@edfi/met
 import path from 'path';
 import Sugar from 'sugar';
 import { CopyOptions } from '../CopyOptions';
+import { directoryExcludeList } from './DeployConstants';
 
 const extensionPath: string = 'Ed-Fi-ODS-Implementation/Application/EdFi.Ods.Extensions.{projectName}/SupportingArtifacts';
 const artifacts: CopyOptions[] = [
@@ -15,9 +16,7 @@ const artifacts: CopyOptions[] = [
 
 function deployExtensionArtifacts(metaEdConfiguration: MetaEdConfiguration): void {
   const { artifactDirectory, deployDirectory } = metaEdConfiguration;
-  const projectsNames: string[] = fs
-    .readdirSync(artifactDirectory)
-    .filter((x: string) => !['Documentation', 'EdFi'].includes(x));
+  const projectsNames: string[] = fs.readdirSync(artifactDirectory).filter((x: string) => !directoryExcludeList.includes(x));
 
   projectsNames.forEach((projectName: string) => {
     artifacts.forEach((artifact: CopyOptions) => {

--- a/packages/metaed-odsapi-deploy/src/task/DeployExtensionV6.ts
+++ b/packages/metaed-odsapi-deploy/src/task/DeployExtensionV6.ts
@@ -4,6 +4,7 @@ import { Logger, versionSatisfies } from '@edfi/metaed-core';
 import path from 'path';
 import Sugar from 'sugar';
 import { CopyOptions } from '../CopyOptions';
+import { directoryExcludeList } from './DeployConstants';
 
 const extensionPath: string = 'Ed-Fi-ODS-Implementation/Application/EdFi.Ods.Extensions.{projectName}/Artifacts';
 const artifacts: CopyOptions[] = [
@@ -18,9 +19,7 @@ const artifacts: CopyOptions[] = [
 
 function deployExtensionArtifacts(metaEdConfiguration: MetaEdConfiguration): void {
   const { artifactDirectory, deployDirectory } = metaEdConfiguration;
-  const projectsNames: string[] = fs
-    .readdirSync(artifactDirectory)
-    .filter((x: string) => !['Documentation', 'EdFi'].includes(x));
+  const projectsNames: string[] = fs.readdirSync(artifactDirectory).filter((x: string) => !directoryExcludeList.includes(x));
 
   projectsNames.forEach((projectName: string) => {
     artifacts.forEach((artifact: CopyOptions) => {

--- a/packages/metaed-odsapi-deploy/src/task/ExtensionProjectsExists.ts
+++ b/packages/metaed-odsapi-deploy/src/task/ExtensionProjectsExists.ts
@@ -2,14 +2,13 @@ import { Logger, MetaEdConfiguration, SemVer, versionSatisfies } from '@edfi/met
 import fs from 'fs-extra';
 import path from 'path';
 import Sugar from 'sugar';
+import { directoryExcludeList } from './DeployConstants';
 
 const projectPaths: string[] = ['Ed-Fi-ODS-Implementation/Application/EdFi.Ods.Extensions.{projectName}/'];
 
 export function extensionProjectsExists(metaEdConfiguration: MetaEdConfiguration): boolean {
   const { artifactDirectory, deployDirectory } = metaEdConfiguration;
-  const projectsNames: string[] = fs
-    .readdirSync(artifactDirectory)
-    .filter((x: string) => !['Documentation', 'EdFi'].includes(x));
+  const projectsNames: string[] = fs.readdirSync(artifactDirectory).filter((x: string) => !directoryExcludeList.includes(x));
 
   let result: boolean = true;
 

--- a/packages/metaed-odsapi-deploy/src/task/LegacyDirectoryExists.ts
+++ b/packages/metaed-odsapi-deploy/src/task/LegacyDirectoryExists.ts
@@ -1,6 +1,7 @@
 import { Logger, MetaEdConfiguration, SemVer, versionSatisfies } from '@edfi/metaed-core';
 import fs from 'fs-extra';
 import path from 'path';
+import { directoryExcludeList } from './DeployConstants';
 
 export function legacyCoreDirectoryExists(metaEdConfiguration: MetaEdConfiguration): void {
   const { deployDirectory } = metaEdConfiguration;
@@ -19,9 +20,7 @@ export function legacyCoreDirectoryExists(metaEdConfiguration: MetaEdConfigurati
 
 export function legacyExtensionDirectoryExists(metaEdConfiguration: MetaEdConfiguration): void {
   const { artifactDirectory, deployDirectory } = metaEdConfiguration;
-  const projectsNames: string[] = fs
-    .readdirSync(artifactDirectory)
-    .filter((x: string) => !['Documentation', 'EdFi'].includes(x));
+  const projectsNames: string[] = fs.readdirSync(artifactDirectory).filter((x: string) => !directoryExcludeList.includes(x));
 
   projectsNames.forEach((projectName: string) => {
     const legacyDirectoryPaths: string[] = [

--- a/packages/metaed-odsapi-deploy/src/task/RefreshProject.ts
+++ b/packages/metaed-odsapi-deploy/src/task/RefreshProject.ts
@@ -4,6 +4,7 @@ import fs from 'fs-extra';
 import touch from 'touch';
 import path from 'path';
 import Sugar from 'sugar';
+import { directoryExcludeList } from './DeployConstants';
 
 const projectPaths: string[] = [
   'Ed-Fi-ODS-Implementation/Application/EdFi.Ods.Extensions.{projectName}/EdFi.Ods.Extensions.{projectName}.csproj',
@@ -11,9 +12,7 @@ const projectPaths: string[] = [
 
 export function refreshProject(metaEdConfiguration: MetaEdConfiguration): void {
   const { artifactDirectory, deployDirectory } = metaEdConfiguration;
-  const projectsNames: string[] = fs
-    .readdirSync(artifactDirectory)
-    .filter((x: string) => !['Documentation', 'EdFi'].includes(x));
+  const projectsNames: string[] = fs.readdirSync(artifactDirectory).filter((x: string) => !directoryExcludeList.includes(x));
 
   projectsNames.forEach((projectName: string) => {
     projectPaths.forEach((projectPath: string) => {

--- a/packages/metaed-odsapi-deploy/src/task/RemoveExtensionArtifacts.ts
+++ b/packages/metaed-odsapi-deploy/src/task/RemoveExtensionArtifacts.ts
@@ -1,10 +1,11 @@
 import { Logger, MetaEdConfiguration, SemVer, versionSatisfies } from '@edfi/metaed-core';
 import fs from 'fs-extra';
 import path from 'path';
+import { directoryExcludeList } from './DeployConstants';
 
 export function removeExtensionArtifacts(metaEdConfiguration: MetaEdConfiguration): boolean {
   const { artifactDirectory, deployDirectory } = metaEdConfiguration;
-  const projectsNames = fs.readdirSync(artifactDirectory).filter((x: string) => !['Documentation', 'EdFi'].includes(x));
+  const projectsNames = fs.readdirSync(artifactDirectory).filter((x: string) => !directoryExcludeList.includes(x));
 
   let result: boolean = true;
 

--- a/packages/metaed-odsapi-deploy/src/task/RemoveExtensionArtifactsV2andV3.ts
+++ b/packages/metaed-odsapi-deploy/src/task/RemoveExtensionArtifactsV2andV3.ts
@@ -1,12 +1,11 @@
 import { Logger, MetaEdConfiguration, SemVer, versionSatisfies } from '@edfi/metaed-core';
 import fs from 'fs-extra';
 import path from 'path';
+import { directoryExcludeList } from './DeployConstants';
 
 export function removeExtensionArtifacts(metaEdConfiguration: MetaEdConfiguration): boolean {
   const { artifactDirectory, deployDirectory } = metaEdConfiguration;
-  const projectsNames: string[] = fs
-    .readdirSync(artifactDirectory)
-    .filter((x: string) => !['Documentation', 'EdFi'].includes(x));
+  const projectsNames: string[] = fs.readdirSync(artifactDirectory).filter((x: string) => !directoryExcludeList.includes(x));
 
   let result: boolean = true;
 


### PR DESCRIPTION
Discovered during MetaEd QA, deploy with extensions thinks the ApiSchema directory is an extension directory.