### PR TITLE
[DMS-533] Add support for exts for type coercion paths

### DIFF
--- a/packages/metaed-plugin-edfi-api-schema/src/enhancer/AllJsonPathsMappingEnhancer.ts
+++ b/packages/metaed-plugin-edfi-api-schema/src/enhancer/AllJsonPathsMappingEnhancer.ts
@@ -496,8 +496,14 @@ function buildJsonPathsMapping(entity: TopLevelEntity) {
 
   allProperties.forEach(({ property, propertyModifier }) => {
     const topLevelName = topLevelApiNameOnEntity(entity, property);
-    const jsonPathRootString =
-      entity.type === 'associationExtension' || entity.type === 'domainEntityExtension' ? '$._ext' : '$';
+    let jsonPathRootString = '$';
+    const referenceProperty: ReferentialProperty = property as ReferentialProperty;
+
+    if (entity.type === 'associationExtension' || entity.type === 'domainEntityExtension') {
+      const endpointName = referenceProperty.namespace.projectName.toLocaleLowerCase() as string;
+      jsonPathRootString += `._ext.${endpointName}`;
+    }
+
     const schemaObjectBaseName = appendNextJsonPathName(
       jsonPathRootString as JsonPath,
       topLevelName,

--- a/packages/metaed-plugin-edfi-api-schema/src/enhancer/MergeJsonPathsMappingEnhancer.ts
+++ b/packages/metaed-plugin-edfi-api-schema/src/enhancer/MergeJsonPathsMappingEnhancer.ts
@@ -476,8 +476,13 @@ function buildJsonPathsMapping(entity: TopLevelEntity) {
 
   allProperties.forEach(({ property, propertyModifier }) => {
     const topLevelName = topLevelApiNameOnEntity(entity, property);
-    const jsonPathRootString =
-      entity.type === 'associationExtension' || entity.type === 'domainEntityExtension' ? '$._ext' : '$';
+    let jsonPathRootString = '$';
+    const referenceProperty: ReferentialProperty = property as ReferentialProperty;
+    if (entity.type === 'associationExtension' || entity.type === 'domainEntityExtension') {
+      const endpointName = referenceProperty.namespace.projectName.toLocaleLowerCase() as string;
+      jsonPathRootString += `._ext.${endpointName}`;
+    }
+
     const schemaObjectBaseName = appendNextJsonPathName(
       jsonPathRootString as JsonPath,
       topLevelName,

--- a/packages/metaed-plugin-edfi-api-schema/test/enhancer/AllJsonPathsMappingEnhancer.test.ts
+++ b/packages/metaed-plugin-edfi-api-schema/test/enhancer/AllJsonPathsMappingEnhancer.test.ts
@@ -2800,7 +2800,7 @@ describe('when building simple domain entity extension', () => {
         "StringProperty": Array [
           Object {
             "entityName": "DomainEntityName",
-            "jsonPath": "$._ext.stringProperty",
+            "jsonPath": "$._ext.edfi.stringProperty",
             "propertyName": "StringProperty",
           },
         ],

--- a/packages/metaed-plugin-edfi-api-schema/test/enhancer/ApiSchemaBuildingEnhancer.test.ts
+++ b/packages/metaed-plugin-edfi-api-schema/test/enhancer/ApiSchemaBuildingEnhancer.test.ts
@@ -3408,7 +3408,7 @@ describe('when domain entity extension references domain entity in different nam
     expect(extensionNamespace.data.edfiApiSchema.apiSchema.projectSchema.resourceSchemas.entityNames.numericJsonPaths)
       .toMatchInlineSnapshot(`
       Array [
-        "$._ext.referencedEntityNameReference.referencedIdentity",
+        "$._ext.edfi.referencedEntityNameReference.referencedIdentity",
       ]
     `);
   });
@@ -3427,7 +3427,7 @@ describe('when domain entity extension references domain entity in different nam
           "referenceJsonPaths": Array [
             Object {
               "identityJsonPath": "$.referencedIdentity",
-              "referenceJsonPath": "$._ext.referencedEntityNameReference.referencedIdentity",
+              "referenceJsonPath": "$._ext.edfi.referencedEntityNameReference.referencedIdentity",
               "type": "number",
             },
           ],

--- a/packages/metaed-plugin-edfi-api-schema/test/enhancer/MergeJsonPathsMappingEnhancer.test.ts
+++ b/packages/metaed-plugin-edfi-api-schema/test/enhancer/MergeJsonPathsMappingEnhancer.test.ts
@@ -3064,7 +3064,7 @@ describe('when building simple domain entity extension', () => {
         "StringProperty": Array [
           Object {
             "entityName": "DomainEntityName",
-            "jsonPath": "$._ext.stringProperty",
+            "jsonPath": "$._ext.edfi.stringProperty",
             "propertyName": "StringProperty",
           },
         ],

--- a/packages/metaed-plugin-edfi-api-schema/test/enhancer/TypeCoercionJsonPathsEnhancer.test.ts
+++ b/packages/metaed-plugin-edfi-api-schema/test/enhancer/TypeCoercionJsonPathsEnhancer.test.ts
@@ -243,7 +243,7 @@ describe('when building domain entity extension with all the simple non-collecti
     const booleanJsonPaths = entity?.data.edfiApiSchema.booleanJsonPaths;
     expect(booleanJsonPaths).toMatchInlineSnapshot(`
       Array [
-        "$._ext.optionalBooleanProperty",
+        "$._ext.edfi.optionalBooleanProperty",
       ]
     `);
   });
@@ -253,9 +253,9 @@ describe('when building domain entity extension with all the simple non-collecti
     const dateTimeJsonPaths = entity?.data.edfiApiSchema.dateTimeJsonPaths;
     expect(dateTimeJsonPaths).toMatchInlineSnapshot(`
       Array [
-        "$._ext.dateTimeIdentity",
-        "$._ext.optionalDateTimeProperty",
-        "$._ext.requiredDatetimeProperty",
+        "$._ext.edfi.dateTimeIdentity",
+        "$._ext.edfi.optionalDateTimeProperty",
+        "$._ext.edfi.requiredDatetimeProperty",
       ]
     `);
   });
@@ -265,17 +265,17 @@ describe('when building domain entity extension with all the simple non-collecti
     const numericJsonPaths = entity?.data.edfiApiSchema.numericJsonPaths;
     expect(numericJsonPaths).toMatchInlineSnapshot(`
       Array [
-        "$._ext.optionalDecimalProperty",
-        "$._ext.optionalPercentProperty",
-        "$._ext.optionalSharedDecimalProperty",
-        "$._ext.optionalSharedIntegerProperty",
-        "$._ext.optionalSharedShortProperty",
-        "$._ext.optionalShortProperty",
-        "$._ext.optionalYear",
-        "$._ext.requiredCurrencyProperty",
-        "$._ext.requiredDurationProperty",
-        "$._ext.requiredIntegerProperty",
-        "$._ext.schoolYearTypeReference.schoolYear",
+        "$._ext.edfi.optionalDecimalProperty",
+        "$._ext.edfi.optionalPercentProperty",
+        "$._ext.edfi.optionalSharedDecimalProperty",
+        "$._ext.edfi.optionalSharedIntegerProperty",
+        "$._ext.edfi.optionalSharedShortProperty",
+        "$._ext.edfi.optionalShortProperty",
+        "$._ext.edfi.optionalYear",
+        "$._ext.edfi.requiredCurrencyProperty",
+        "$._ext.edfi.requiredDurationProperty",
+        "$._ext.edfi.requiredIntegerProperty",
+        "$._ext.edfi.schoolYearTypeReference.schoolYear",
       ]
     `);
   });

--- a/packages/metaed-plugin-edfi-api-schema/test/integration/artifact/v7_2/tpdm-api-schema-authoritative.json
+++ b/packages/metaed-plugin-edfi-api-schema/test/integration/artifact/v7_2/tpdm-api-schema-authoritative.json
@@ -9696,38 +9696,38 @@
       },
       "credentials": {
         "booleanJsonPaths": [
-          "$._ext.boardCertificationIndicator"
+          "$._ext.tpdm.boardCertificationIndicator"
         ],
         "dateTimeJsonPaths": [
         ],
         "documentPathsMapping": {
           "BoardCertificationIndicator": {
             "isReference": false,
-            "path": "$._ext.boardCertificationIndicator",
+            "path": "$._ext.tpdm.boardCertificationIndicator",
             "type": "boolean"
           },
           "CertificationRouteDescriptor": {
             "isDescriptor": true,
             "isReference": true,
-            "path": "$._ext.certificationRouteDescriptor",
+            "path": "$._ext.tpdm.certificationRouteDescriptor",
             "projectName": "TPDM",
             "resourceName": "CertificationRouteDescriptor",
             "type": "string"
           },
           "CertificationTitle": {
             "isReference": false,
-            "path": "$._ext.certificationTitle",
+            "path": "$._ext.tpdm.certificationTitle",
             "type": "string"
           },
           "CredentialStatusDate": {
             "isReference": false,
-            "path": "$._ext.credentialStatusDate",
+            "path": "$._ext.tpdm.credentialStatusDate",
             "type": "date"
           },
           "CredentialStatusDescriptor": {
             "isDescriptor": true,
             "isReference": true,
-            "path": "$._ext.credentialStatusDescriptor",
+            "path": "$._ext.tpdm.credentialStatusDescriptor",
             "projectName": "TPDM",
             "resourceName": "CredentialStatusDescriptor",
             "type": "string"
@@ -9735,7 +9735,7 @@
           "EducatorRoleDescriptor": {
             "isDescriptor": true,
             "isReference": true,
-            "path": "$._ext.educatorRoleDescriptor",
+            "path": "$._ext.tpdm.educatorRoleDescriptor",
             "projectName": "TPDM",
             "resourceName": "EducatorRoleDescriptor",
             "type": "string"
@@ -9747,12 +9747,12 @@
             "referenceJsonPaths": [
               {
                 "identityJsonPath": "$.personId",
-                "referenceJsonPath": "$._ext.personReference.personId",
+                "referenceJsonPath": "$._ext.tpdm.personReference.personId",
                 "type": "string"
               },
               {
                 "identityJsonPath": "$.sourceSystemDescriptor",
-                "referenceJsonPath": "$._ext.personReference.sourceSystemDescriptor",
+                "referenceJsonPath": "$._ext.tpdm.personReference.sourceSystemDescriptor",
                 "type": "string"
               }
             ],
@@ -9765,22 +9765,22 @@
             "referenceJsonPaths": [
               {
                 "identityJsonPath": "$.educationOrganizationReference.educationOrganizationId",
-                "referenceJsonPath": "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.educationOrganizationId",
+                "referenceJsonPath": "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.educationOrganizationId",
                 "type": "number"
               },
               {
                 "identityJsonPath": "$.schoolYearTypeReference.schoolYear",
-                "referenceJsonPath": "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.schoolYear",
+                "referenceJsonPath": "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.schoolYear",
                 "type": "string"
               },
               {
                 "identityJsonPath": "$.studentReference.studentUniqueId",
-                "referenceJsonPath": "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.studentUniqueId",
+                "referenceJsonPath": "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.studentUniqueId",
                 "type": "string"
               },
               {
                 "identityJsonPath": "$.termDescriptor",
-                "referenceJsonPath": "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.termDescriptor",
+                "referenceJsonPath": "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.termDescriptor",
                 "type": "string"
               }
             ],
@@ -9900,8 +9900,8 @@
           "type": "object"
         },
         "numericJsonPaths": [
-          "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.educationOrganizationId",
-          "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.schoolYear"
+          "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.educationOrganizationId",
+          "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.schoolYear"
         ],
         "resourceName": "Credential",
         "securityElements": {
@@ -15336,7 +15336,7 @@
             "referenceJsonPaths": [
               {
                 "identityJsonPath": "$.postSecondaryInstitutionId",
-                "referenceJsonPath": "$._ext.postSecondaryInstitutionReference.postSecondaryInstitutionId",
+                "referenceJsonPath": "$._ext.tpdm.postSecondaryInstitutionReference.postSecondaryInstitutionId",
                 "type": "number"
               }
             ],
@@ -15376,7 +15376,7 @@
           "type": "object"
         },
         "numericJsonPaths": [
-          "$._ext.postSecondaryInstitutionReference.postSecondaryInstitutionId"
+          "$._ext.tpdm.postSecondaryInstitutionReference.postSecondaryInstitutionId"
         ],
         "resourceName": "School",
         "securityElements": {
@@ -15567,12 +15567,12 @@
             "referenceJsonPaths": [
               {
                 "identityJsonPath": "$.personId",
-                "referenceJsonPath": "$._ext.personReference.personId",
+                "referenceJsonPath": "$._ext.tpdm.personReference.personId",
                 "type": "string"
               },
               {
                 "identityJsonPath": "$.sourceSystemDescriptor",
-                "referenceJsonPath": "$._ext.personReference.sourceSystemDescriptor",
+                "referenceJsonPath": "$._ext.tpdm.personReference.sourceSystemDescriptor",
                 "type": "string"
               }
             ],

--- a/packages/metaed-plugin-edfi-api-schema/test/integration/artifact/v7_3/tpdm-api-schema-authoritative.json
+++ b/packages/metaed-plugin-edfi-api-schema/test/integration/artifact/v7_3/tpdm-api-schema-authoritative.json
@@ -9696,38 +9696,38 @@
       },
       "credentials": {
         "booleanJsonPaths": [
-          "$._ext.boardCertificationIndicator"
+          "$._ext.tpdm.boardCertificationIndicator"
         ],
         "dateTimeJsonPaths": [
         ],
         "documentPathsMapping": {
           "BoardCertificationIndicator": {
             "isReference": false,
-            "path": "$._ext.boardCertificationIndicator",
+            "path": "$._ext.tpdm.boardCertificationIndicator",
             "type": "boolean"
           },
           "CertificationRouteDescriptor": {
             "isDescriptor": true,
             "isReference": true,
-            "path": "$._ext.certificationRouteDescriptor",
+            "path": "$._ext.tpdm.certificationRouteDescriptor",
             "projectName": "TPDM",
             "resourceName": "CertificationRouteDescriptor",
             "type": "string"
           },
           "CertificationTitle": {
             "isReference": false,
-            "path": "$._ext.certificationTitle",
+            "path": "$._ext.tpdm.certificationTitle",
             "type": "string"
           },
           "CredentialStatusDate": {
             "isReference": false,
-            "path": "$._ext.credentialStatusDate",
+            "path": "$._ext.tpdm.credentialStatusDate",
             "type": "date"
           },
           "CredentialStatusDescriptor": {
             "isDescriptor": true,
             "isReference": true,
-            "path": "$._ext.credentialStatusDescriptor",
+            "path": "$._ext.tpdm.credentialStatusDescriptor",
             "projectName": "TPDM",
             "resourceName": "CredentialStatusDescriptor",
             "type": "string"
@@ -9735,7 +9735,7 @@
           "EducatorRoleDescriptor": {
             "isDescriptor": true,
             "isReference": true,
-            "path": "$._ext.educatorRoleDescriptor",
+            "path": "$._ext.tpdm.educatorRoleDescriptor",
             "projectName": "TPDM",
             "resourceName": "EducatorRoleDescriptor",
             "type": "string"
@@ -9747,12 +9747,12 @@
             "referenceJsonPaths": [
               {
                 "identityJsonPath": "$.personId",
-                "referenceJsonPath": "$._ext.personReference.personId",
+                "referenceJsonPath": "$._ext.tpdm.personReference.personId",
                 "type": "string"
               },
               {
                 "identityJsonPath": "$.sourceSystemDescriptor",
-                "referenceJsonPath": "$._ext.personReference.sourceSystemDescriptor",
+                "referenceJsonPath": "$._ext.tpdm.personReference.sourceSystemDescriptor",
                 "type": "string"
               }
             ],
@@ -9765,22 +9765,22 @@
             "referenceJsonPaths": [
               {
                 "identityJsonPath": "$.educationOrganizationReference.educationOrganizationId",
-                "referenceJsonPath": "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.educationOrganizationId",
+                "referenceJsonPath": "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.educationOrganizationId",
                 "type": "number"
               },
               {
                 "identityJsonPath": "$.schoolYearTypeReference.schoolYear",
-                "referenceJsonPath": "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.schoolYear",
+                "referenceJsonPath": "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.schoolYear",
                 "type": "string"
               },
               {
                 "identityJsonPath": "$.studentReference.studentUniqueId",
-                "referenceJsonPath": "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.studentUniqueId",
+                "referenceJsonPath": "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.studentUniqueId",
                 "type": "string"
               },
               {
                 "identityJsonPath": "$.termDescriptor",
-                "referenceJsonPath": "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.termDescriptor",
+                "referenceJsonPath": "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.termDescriptor",
                 "type": "string"
               }
             ],
@@ -9900,8 +9900,8 @@
           "type": "object"
         },
         "numericJsonPaths": [
-          "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.educationOrganizationId",
-          "$._ext.studentAcademicRecords[*].studentAcademicRecordReference.schoolYear"
+          "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.educationOrganizationId",
+          "$._ext.tpdm.studentAcademicRecords[*].studentAcademicRecordReference.schoolYear"
         ],
         "resourceName": "Credential",
         "securityElements": {
@@ -15336,7 +15336,7 @@
             "referenceJsonPaths": [
               {
                 "identityJsonPath": "$.postSecondaryInstitutionId",
-                "referenceJsonPath": "$._ext.postSecondaryInstitutionReference.postSecondaryInstitutionId",
+                "referenceJsonPath": "$._ext.tpdm.postSecondaryInstitutionReference.postSecondaryInstitutionId",
                 "type": "number"
               }
             ],
@@ -15376,7 +15376,7 @@
           "type": "object"
         },
         "numericJsonPaths": [
-          "$._ext.postSecondaryInstitutionReference.postSecondaryInstitutionId"
+          "$._ext.tpdm.postSecondaryInstitutionReference.postSecondaryInstitutionId"
         ],
         "resourceName": "School",
         "securityElements": {
@@ -15567,12 +15567,12 @@
             "referenceJsonPaths": [
               {
                 "identityJsonPath": "$.personId",
-                "referenceJsonPath": "$._ext.personReference.personId",
+                "referenceJsonPath": "$._ext.tpdm.personReference.personId",
                 "type": "string"
               },
               {
                 "identityJsonPath": "$.sourceSystemDescriptor",
-                "referenceJsonPath": "$._ext.personReference.sourceSystemDescriptor",
+                "referenceJsonPath": "$._ext.tpdm.personReference.sourceSystemDescriptor",
                 "type": "string"
               }
             ],


### PR DESCRIPTION
As part of this ticket where ever you have $._ext after that you will have extensionname . example here tpdm for tpdm extension 