### PR TITLE
[DMS-532] Add support for exts in Equality Constraints

### DIFF
--- a/packages/metaed-plugin-edfi-api-schema/src/Utility.ts
+++ b/packages/metaed-plugin-edfi-api-schema/src/Utility.ts
@@ -1,8 +1,10 @@
-import { EntityProperty, NoEntityProperty, TopLevelEntity } from '@edfi/metaed-core';
+import { EntityProperty, MetaEdPropertyPath, NoEntityProperty, TopLevelEntity } from '@edfi/metaed-core';
 import * as inflection from 'inflection';
 import { invariant } from 'ts-invariant';
 import { EntityPropertyApiSchemaData } from './model/EntityPropertyApiSchemaData';
 import { FlattenedIdentityProperty } from './model/FlattenedIdentityProperty';
+import { EntityApiSchemaData } from './model/EntityApiSchemaData';
+import { JsonPathsInfo } from './model/JsonPathsMapping';
 
 /**
  * Simplified MetaEd top level reference checking, supporting
@@ -159,4 +161,19 @@ export function findIdenticalRoleNamePatternPrefix(flattenedIdentityProperty: Fl
   invariant(flattenedIdentityProperty.propertyChain.length > 0, 'propertyChain should not be empty');
 
   return flattenedIdentityProperty.propertyChain.reduce(identicalRoleNamePatternPrefixReducer, '');
+}
+
+/**
+ * Searches the given path in the entity's mergeJsonPathsMapping.
+ * Recursively searches the baseEntity if not found.
+ */
+export function findMergeJsonPathsMapping(entity: TopLevelEntity | null, path: MetaEdPropertyPath): JsonPathsInfo | null {
+  if (!entity) {
+    // Reached the top of the entity hierarchy without finding the path
+    return null;
+  }
+
+  const { mergeJsonPathsMapping } = entity.data.edfiApiSchema as EntityApiSchemaData;
+  const result = mergeJsonPathsMapping[path];
+  return result || findMergeJsonPathsMapping(entity.baseEntity, path);
 }

--- a/packages/metaed-plugin-edfi-api-schema/src/enhancer/ColumnConflictEqualityConstraintEnhancer.ts
+++ b/packages/metaed-plugin-edfi-api-schema/src/enhancer/ColumnConflictEqualityConstraintEnhancer.ts
@@ -5,6 +5,7 @@ import { EntityApiSchemaData } from '../model/EntityApiSchemaData';
 import { JsonPath } from '../model/api-schema/JsonPath';
 import { EqualityConstraint } from '../model/EqualityConstraint';
 import { JsonPathsInfo } from '../model/JsonPathsMapping';
+import { findMergeJsonPathsMapping } from '../Utility';
 
 /**
  * Returns all the relational Table objects
@@ -49,25 +50,20 @@ export function enhance(metaEd: MetaEdEnvironment): EnhancerResult {
 
   tables.forEach((table: Table) => {
     table.columnConflictPaths.forEach((columnConflictPath: ColumnConflictPath) => {
-      // We don't support extension tables at this time
-      if (
-        columnConflictPath.firstOriginalEntity.type === 'associationExtension' ||
-        columnConflictPath.secondOriginalEntity.type === 'associationExtension' ||
-        columnConflictPath.firstOriginalEntity.type === 'domainEntityExtension' ||
-        columnConflictPath.secondOriginalEntity.type === 'domainEntityExtension'
-      ) {
-        return;
-      }
-
       if (columnConflictPath.firstOriginalEntity !== columnConflictPath.secondOriginalEntity)
         // Must be on same resource to be a resource equality constraint
         return;
 
-      const { equalityConstraints, mergeJsonPathsMapping } = columnConflictPath.firstOriginalEntity.data
-        .edfiApiSchema as EntityApiSchemaData;
+      const { equalityConstraints } = columnConflictPath.firstOriginalEntity.data.edfiApiSchema as EntityApiSchemaData;
 
-      const firstPathInMapping: JsonPathsInfo | undefined = mergeJsonPathsMapping[columnConflictPath.firstPath];
-      const secondPathInMapping: JsonPathsInfo | undefined = mergeJsonPathsMapping[columnConflictPath.secondPath];
+      const firstPathInMapping: JsonPathsInfo | null = findMergeJsonPathsMapping(
+        columnConflictPath.firstOriginalEntity,
+        columnConflictPath.firstPath,
+      );
+      const secondPathInMapping: JsonPathsInfo | null = findMergeJsonPathsMapping(
+        columnConflictPath.firstOriginalEntity,
+        columnConflictPath.secondPath,
+      );
 
       invariant(
         firstPathInMapping != null,


### PR DESCRIPTION
Note that TPDM extends `Credential`, `School`, and `SurveyResponse` but it doesn't extend their `equalityConstraints`, hence there are no changes in the authoritative test files.