### PR TITLE
[METAED-1650] Retarget API Schema packages to net10.0

### DIFF
--- a/eng/ApiSchema/EdFi.DataStandard.ApiSchema.csproj
+++ b/eng/ApiSchema/EdFi.DataStandard.ApiSchema.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <RootNamespace>EdFi.DataStandard$(DataStandardVersion).ApiSchema</RootNamespace>
         <NoWarn>NU5110,NU5111</NoWarn>

--- a/eng/ApiSchema/EdFi.Homograph.ApiSchema.csproj
+++ b/eng/ApiSchema/EdFi.Homograph.ApiSchema.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <RootNamespace>EdFi.Homograph.ApiSchema</RootNamespace>
         <NoWarn>NU5110,NU5111</NoWarn>

--- a/eng/ApiSchema/EdFi.Sample.ApiSchema.csproj
+++ b/eng/ApiSchema/EdFi.Sample.ApiSchema.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <RootNamespace>EdFi.Sample.ApiSchema</RootNamespace>
         <NoWarn>NU5110,NU5111</NoWarn>

--- a/eng/ApiSchema/EdFi.TPDM.ApiSchema.csproj
+++ b/eng/ApiSchema/EdFi.TPDM.ApiSchema.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <IsPackable>true</IsPackable>
         <RootNamespace>EdFi.TPDM.ApiSchema</RootNamespace>
         <NoWarn>NU5110,NU5111</NoWarn>


### PR DESCRIPTION
- Changes `<TargetFramework>net8.0</TargetFramework>` to `<TargetFramework>net10.0</TargetFramework>` in all four API Schema csproj files under eng/ApiSchema/, so published NuGet DLLs are compatible with the DMS consumer which targets .NET 10.
- DMS-side package-reference updates (bumping EdFi.*.ApiSchema refs in src/Directory.Packages.props) are not in this PR; they are a separate follow-up PR in the DMS repo
