### PR TITLE
[METAED-1657] Bump Subdomain validator to skip DS 6.0

### DIFF
--- a/packages/metaed-plugin-edfi-unified/src/validator/Subdomain/DescriptorSubdomainItemMustMatchTopLevelEntity.ts
+++ b/packages/metaed-plugin-edfi-unified/src/validator/Subdomain/DescriptorSubdomainItemMustMatchTopLevelEntity.ts
@@ -19,7 +19,7 @@ function getFailure(domainItem: DomainItem, name: string, failureMessage: string
 export function validate(metaEd: MetaEdEnvironment): ValidationFailure[] {
   const failures: ValidationFailure[] = [];
 
-  if (!versionSatisfies(metaEd.dataStandardVersion, '>4.0.0')) {
+  if (!versionSatisfies(metaEd.dataStandardVersion, '>=6.1.0')) {
     return failures;
   }
 

--- a/packages/metaed-plugin-edfi-unified/test/validator/Subdomain/DescriptorSubdomainItemMustMatchTopLevelEntity.test.ts
+++ b/packages/metaed-plugin-edfi-unified/test/validator/Subdomain/DescriptorSubdomainItemMustMatchTopLevelEntity.test.ts
@@ -107,7 +107,7 @@ describe('when validating descriptor subdomain item does not match top level ent
   let coreNamespace: any = null;
 
   beforeAll(() => {
-    metaEd.dataStandardVersion = '5.0.0';
+    metaEd.dataStandardVersion = '6.1.0';
 
     MetaEdTextBuilder.build()
       .withBeginNamespace('EdFi')


### PR DESCRIPTION
## Summary
- Bump `DescriptorSubdomainItemMustMatchTopLevelEntity` version gate from `>4.0.0` to `>=6.1.0` so DS 6.0 passes validation
- DS 6.0 has a typo in `ReportCard.metaed` (`PerformanceBasedConversion` instead of `PerformanceBaseConversion`) that triggers a false validation error — the typo is fixed in DS 6.1 and DS 6.0 will not be updated
- Update test `dataStandardVersion` from `5.0.0` to `6.1.0` to match the new gate

## Test plan
- [x] Unit tests pass for `DescriptorSubdomainItemMustMatchTopLevelEntity`
- [x] Verified metaed-console runs DS 6.0 with exit code 0 and no validation errors
