### PR TITLE
[METAED-1633] Remove residual PII column from HTML handbook

### DIFF
--- a/packages/metaed-plugin-edfi-handbook/src/generator/template/EdFiDataHandbookAsHtmlSPAIndex.html
+++ b/packages/metaed-plugin-edfi-handbook/src/generator/template/EdFiDataHandbookAsHtmlSPAIndex.html
@@ -627,7 +627,6 @@
                                             <template x-if="selectedEntity.showIdentityColumn">
                                                 <th>Identity</th>
                                             </template>
-                                            <th>Is Sensitive Data</th>
                                             <th>Cardinality</th>
                                             <th>Definition</th>
                                             <template x-if="showMerge">
@@ -681,7 +680,6 @@
                                                 <template x-if="selectedEntity.showIdentityColumn">
                                                     <td x-text="trueFalseToYesNo(prop.isIdentity)"></td>
                                                 </template>
-                                                <td x-text="trueFalseToYesNo(prop.isSensitiveData)"></td>
                                                 <td x-text="prop.cardinality"></td>
                                                 <td x-text="prop.definition"></td>
                                                 <template x-if="showMerge">


### PR DESCRIPTION
 METAED-1633 was reopened because the "Is Sensitive Data" column still renders in the generated HTML handbook, even though the PII/"is sensitive data" DSL feature was fully
  reverted in #470.

  **Root cause:** PR #470 removed the column from the legacy `EdFiDataHandbookAsHtmlSPADetail.html`, but #448 (METAED-1646, merged earlier) had replaced that template with
  `EdFiDataHandbookAsHtmlSPAIndex.html`, which re-materialized the column. The revert author did not catch the renamed file.

  This PR deletes the two surviving references so the handbook no longer renders a dead / always-blank column (`prop.isSensitiveData` was removed from `HandbookRow` by #470, so
  the binding was already dead).