### PR TITLE
[METAED-1660] Cleanup token permissions in MetaEd workflows

### DIFF
--- a/.github/workflows/api-schema-packaging.yml
+++ b/.github/workflows/api-schema-packaging.yml
@@ -17,6 +17,8 @@ on:
           - "false"
           - "true"
 
+permissions: read-all
+
 env:
   ARTIFACTS_API_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   ARTIFACTS_FEED_URL: https://pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/nuget/v3/index.json

--- a/.github/workflows/api-schema-packaging.yml
+++ b/.github/workflows/api-schema-packaging.yml
@@ -90,7 +90,7 @@ jobs:
         shell: pwsh
     steps:
       - name: Checkout MetaEd-js
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Ed-Fi-Alliance-OSS/MetaEd-js
           path: MetaEd-js/
@@ -98,7 +98,7 @@ jobs:
 
       - name: Checkout Ed-Fi-TPDM-Model (for TPDM only)
         if: matrix.config == 'TPDM'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Ed-Fi-Closed/Ed-Fi-TPDM-Model
           path: Ed-Fi-TPDM-Model/
@@ -107,7 +107,7 @@ jobs:
 
       - name: Checkout Ed-Fi-ODS-Implementation (for Homograph and Sample only)
         if: matrix.config == 'Homograph'  || matrix.config == 'Sample'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Ed-Fi-Alliance-OSS/Ed-Fi-ODS-Implementation
           path: Ed-Fi-ODS-Implementation/
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload MetaEdOutput as Artifact
         if: success()
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5  
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1  
         with:
           name: MetaEdOutput-${{ matrix.config }}-${{ matrix.ds.version }}
           path: ${{ github.workspace }}/MetaEd-js/MetaEdOutput/**/*.* 
@@ -184,14 +184,14 @@ jobs:
         shell: pwsh
     steps:
       - name: Checkout MetaEd-js
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: Ed-Fi-Alliance-OSS/MetaEd-js
           path: MetaEd-js/
           ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Get Artifacts
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: MetaEdOutput-${{ matrix.config }}-${{ matrix.ds.version }}
           path: ./MetaEd-js/MetaEdOutput
@@ -227,7 +227,7 @@ jobs:
 
       - name: Upload Package as Artifact
         if: success()
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5  
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1  
         with:
           name: "EdFi.ApiSchema-NuGet-${{ matrix.config }}-${{ matrix.ds.version }}-1.0.${{ github.run_number }}"
           path: ./MetaEd-js/eng/ApiSchema/*.nupkg
@@ -257,10 +257,10 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Get Artifact
-        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: EdFi.ApiSchema-NuGet-${{ matrix.config }}-${{ matrix.ds-version }}-1.0.${{ github.run_number }}
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -24,6 +24,7 @@ jobs:
     name: Code Analysis
     runs-on: ubuntu-latest
     permissions:
+        contents: read
         security-events: write
     defaults:
       run:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,18 +32,18 @@ jobs:
     steps:
 
       - name: Checkout the Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Dependency Review ("Dependabot on PR")
         if: ${{ github.event_name == 'pull_request' && !github.event.repository.fork }}
-        uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
 
       - name: Initialize CodeQL
         if: success()
-        uses: github/codeql-action/init@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: typescript
 
       - name: Perform CodeQL Analysis
         if: success()
-        uses: github/codeql-action/analyze@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,7 +9,8 @@ on:
     paths:
       - ".github/workflows/copilot-setup-steps.yml"
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   copilot-setup-steps:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -9,8 +9,7 @@ on:
     paths:
       - ".github/workflows/copilot-setup-steps.yml"
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   copilot-setup-steps:

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -13,6 +13,8 @@ on:
       - "packages/**"
       - ".github"
 
+permissions: read-all
+
 jobs:
   scan-actions:
     name: Scan Actions

--- a/.github/workflows/on-issue-opened.yml
+++ b/.github/workflows/on-issue-opened.yml
@@ -9,13 +9,14 @@ on:
   issues:
     types: [opened]
 
-permissions:
-  issues: write
+permissions: read-all
 
 jobs:
   manage-community-issues:
     runs-on: ubuntu-latest
     if: github.event.issue.user.type != 'bot'
+    permissions:
+      issues: write
     steps:
       - name: Check if user has repository access
         id: check-repo-access

--- a/.github/workflows/on-issue-opened.yml
+++ b/.github/workflows/on-issue-opened.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Check if user has repository access
         id: check-repo-access
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             try {
@@ -40,7 +40,7 @@ jobs:
 
       - name: Close community issue with helpful message
         if: steps.check-repo-access.outputs.result == 'false'
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const message = `Thank you for your interest in Ed-Fi!

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -39,7 +39,7 @@ jobs:
 
       - name: Node modules cache
         id: modules-cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
@@ -61,10 +61,10 @@ jobs:
       pull-requests: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -72,7 +72,7 @@ jobs:
 
       - name: Node modules cache
         id: modules-cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
@@ -126,10 +126,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -137,7 +137,7 @@ jobs:
 
       - name: Node modules cache
         id: modules-cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}
@@ -182,10 +182,10 @@ jobs:
       SA_PASSWORD: abcdefgh1!
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Setup Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: "npm"
@@ -193,7 +193,7 @@ jobs:
 
       - name: Node modules cache
         id: modules-cache
-        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: "**/node_modules"
           key: ${{ runner.os }}-modules-${{ hashFiles('**/package-lock.json') }}

--- a/.github/workflows/on-pullrequest.yml
+++ b/.github/workflows/on-pullrequest.yml
@@ -19,6 +19,8 @@ on:
           - "false"
           - "true"
 
+permissions: read-all
+
 jobs:
   lint:
     name: Lint
@@ -53,6 +55,10 @@ jobs:
     name: Unit Test
     needs: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -87,7 +93,7 @@ jobs:
         timeout-minutes: 10
 
       - name: Unit Test Report
-        uses: EnricoMi/publish-unit-test-result-action@f355d34d53ad4e7f506f699478db2dd71da9de5f # v2.15.1
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         if: success() || failure()
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
@@ -101,6 +107,10 @@ jobs:
     name: SQL Server Tests
     needs: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     env:
       SA_PASSWORD: abcdefgh1!
     services:
@@ -150,7 +160,7 @@ jobs:
           JEST_JUNIT_OUTPUT_DIR: sqlserver-tests
 
       - name: SQLServer Test Report
-        uses: EnricoMi/publish-unit-test-result-action@f355d34d53ad4e7f506f699478db2dd71da9de5f # v2.15.1
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         if: success() || failure()
         with:
           commit: ${{ github.event.workflow_run.head_sha }}
@@ -164,6 +174,10 @@ jobs:
     name: PostgreSQL Tests
     needs: lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     env:
       SA_PASSWORD: abcdefgh1!
     steps:
@@ -171,7 +185,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "22"
           cache: "npm"
@@ -202,7 +216,7 @@ jobs:
           JEST_JUNIT_OUTPUT_DIR: postgresql-tests
 
       - name: PostgreSQL Test Report
-        uses: EnricoMi/publish-unit-test-result-action@f355d34d53ad4e7f506f699478db2dd71da9de5f # v2.15.1
+        uses: EnricoMi/publish-unit-test-result-action@c950f6fb443cb5af20a377fd0dfaa78838901040 # v2.23.0
         if: success() || failure()
         with:
           commit: ${{ github.event.workflow_run.head_sha }}

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -9,6 +9,8 @@ on:
     types:
       - released
 
+permissions: read-all
+
 env:
   ARTIFACTS_API_KEY: ${{ secrets.AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN }}
   ARTIFACTS_PACKAGES_URL: "https://pkgs.dev.azure.com/ed-fi-alliance/9f7770ac-66d9-4fbc-b81e-b5ad79002b62/_apis/packaging/feeds/338858dc-b976-4355-ab70-5e713b1f56be/npm/packagesBatch?api-version=7.1-preview.1"
@@ -19,6 +21,8 @@ jobs:
   delete-pre-releases:
     name: Delete Unnecessary Pre-Releases
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout the repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -25,7 +25,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Delete other pre-releases and their tags
         shell: pwsh
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Promote Package
         shell: pwsh

--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -21,6 +21,8 @@ on:
     branches:
       - main
 
+permissions: read-all
+
 jobs:
   publish-dev:
     name: Publish Dev

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,6 +26,8 @@ on:
           - "false"
           - "true"
 
+permissions: read-all
+
 jobs:
   publish-major:
     name: Publish Release

--- a/.github/workflows/retry-publish.yml
+++ b/.github/workflows/retry-publish.yml
@@ -16,6 +16,8 @@ on:
           - "false"
           - "true"
 
+permissions: read-all
+
 jobs:
   retry-publish:
     name: Retry Publish

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -45,12 +45,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           token: ${{ secrets.EDFI_BUILD_AGENT_PAT }}
 
       - name: Set up Node
-        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           check-latest: true

--- a/.github/workflows/reusable-publish.yml
+++ b/.github/workflows/reusable-publish.yml
@@ -32,6 +32,8 @@ on:
       AZURE_ARTIFACTS_PERSONAL_ACCESS_TOKEN :
         required: true
 
+permissions: read-all
+
 env:
   NPM_REGISTRY: //pkgs.dev.azure.com/ed-fi-alliance/Ed-Fi-Alliance-OSS/_packaging/EdFi/npm/registry/
 
@@ -48,7 +50,7 @@ jobs:
           token: ${{ secrets.EDFI_BUILD_AGENT_PAT }}
 
       - name: Set up Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
           node-version: "22"
           check-latest: true
@@ -62,7 +64,7 @@ jobs:
 
       - name: Import GPG key
         id: import-gpg
-        uses: crazy-max/ghaction-import-gpg@82a020f1f7f605c65dd2449b392a52c3fcfef7ef # v6.0.0
+        uses: crazy-max/ghaction-import-gpg@cb9bde2e2525e640591a934b1fd28eef1dcaf5e5 # v6.2.0
         with:
           gpg_private_key: ${{ secrets.EDFIBUILDAGENT_PRIVATE_KEY }}
           passphrase: ${{ secrets.EDFIBUILDAGENT_PASSPHRASE }}
@@ -113,5 +115,5 @@ jobs:
       # Enable tmate debugging if the input option was provided (https://github.com/marketplace/actions/debugging-with-tmate)
       - name: Setup tmate session
         if: always() && inputs.debug_enabled == 'true'
-        uses: mxschmitt/action-tmate@a283f9441d2d96eb62436dc46d7014f5d357ac22 # v3.17
+        uses: mxschmitt/action-tmate@e5c7151931ca95bad1c6f4190c730ecf8c7dde48 # v3.19
         timeout-minutes: 10

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -38,7 +38,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: scorecard.sarif
           results_format: sarif

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
 
@@ -60,7 +60,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: Upload artifact
-        uses: actions/upload-artifact@6f51ac03b9356f520e9adb1b1b7802705f340c2b # v4.5
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: Scorecard SARIF file
           path: scorecard.sarif
@@ -68,6 +68,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: scorecard.sarif


### PR DESCRIPTION
## Summary

  Hardens GitHub Actions workflow security by applying least-privilege token permissions and pinning action dependencies to newer versions.

  Token permissions

  - Added a top-level permissions: read-all default to workflows that were missing an explicit scope (api-schema-packaging, dependency-review, on-pullrequest, on-release, publish-dev, publish-release, retry-publish, reusable-publish), so tokens are read-only by default.
  - Moved write permissions down to the specific jobs that actually need them, rather than granting them workflow-wide:
    - on-issue-opened: issues: write scoped to the manage-community-issues job.
    - on-pullrequest: checks: write / pull-requests: write scoped to the test-report jobs (Unit, SQL Server, PostgreSQL).
    - on-release: contents: write scoped to the delete-pre-releases job.
  - codeql-analysis: added explicit contents: read alongside the existing security-events: write.
  - copilot-setup-steps: normalized to read-all.

  Action version bumps (SHA-pinned)

  - EnricoMi/publish-unit-test-result-action → v2.23.0
  - actions/setup-node → v4.1.0
  - crazy-max/ghaction-import-gpg → v6.2.0
  - mxschmitt/action-tmate → v3.19
  - ossf/scorecard-action → v2.4.3

  No application/source code changes — CI/workflow configuration only.


 ## Action From → To     
- actions/checkout                                      v4.2.2 → v7.0.0
- actions/setup-node                                  v4.1.0 → v6.4.0   
- actions/upload-artifact                             v4.5 → v7.0.1     
- actions/download-artifact                        v4.1.8 → v8.0.1   
- actions/cache                                           v4.2 → v6.1.0     
- actions/dependency-review-action          v4.5.0 → v5.0.0   
- actions/github-script                                v8.0.0 → v9.0.0   
- github/codeql-action                               v3.28.0 → v4.36.3 
